### PR TITLE
Set env var for berkshelf version and usage in centos6 packer config

### DIFF
--- a/build_ami.sh
+++ b/build_ami.sh
@@ -34,6 +34,7 @@ RC=0
 rm -rf ../vendor/cookbooks || RC=1
 berks vendor ../vendor/cookbooks || RC=1
 export BUILD_DATE=`date +%Y%m%d%H%M`
+export BERKSHELF_VERSION=`berks version`
 
 case $os in
 all)

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -7,6 +7,7 @@
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
     "build_date" : "{{env `BUILD_DATE`}}"
+    "berkshelf_version" : "{{env `BERKSHELF_VERSION`}}"
   },
   "builders": [{
     "type": "amazon-ebs",

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -6,7 +6,7 @@
     "chef_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
-    "build_date" : "{{env `BUILD_DATE`}}"
+    "build_date" : "{{env `BUILD_DATE`}}",
     "berkshelf_version" : "{{env `BERKSHELF_VERSION`}}"
   },
   "builders": [{


### PR DESCRIPTION
The berkshelf version is used but not set - so set it as env var.