### PR TITLE
Revert "Set env var for berkshelf version and usage in centos6 packer config"

### DIFF
--- a/build_ami.sh
+++ b/build_ami.sh
@@ -34,7 +34,6 @@ RC=0
 rm -rf ../vendor/cookbooks || RC=1
 berks vendor ../vendor/cookbooks || RC=1
 export BUILD_DATE=`date +%Y%m%d%H%M`
-export BERKSHELF_VERSION=`berks version`
 
 case $os in
 all)

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -6,8 +6,7 @@
     "chef_version" : "",
     "build_for" : "{{env `BUILD_FOR`}}",
     "ami_perms" : "{{env `AMI_PERMS`}}",
-    "build_date" : "{{env `BUILD_DATE`}}",
-    "berkshelf_version" : "{{env `BERKSHELF_VERSION`}}"
+    "build_date" : "{{env `BUILD_DATE`}}"
   },
   "builders": [{
     "type": "amazon-ebs",


### PR DESCRIPTION
Reverts awslabs/cfncluster-cookbook#5

The berkshelf version comes from the packer_variables.json.