### PR TITLE
Upgrade torque to 6.0.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,8 +28,8 @@ default['cfncluster']['sge']['url'] = 'http://arc.liv.ac.uk/downloads/SGE/releas
 default['cfncluster']['openlava']['version'] = '3.1.3'
 default['cfncluster']['openlava']['url'] = 'https://github.com/openlava/openlava/archive/3.1.3.tar.gz'
 # Torque software
-default['cfncluster']['torque']['version'] = '6.0.0'
-default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.0.0.tar.gz'
+default['cfncluster']['torque']['version'] = '6.0.1'
+default['cfncluster']['torque']['url'] = 'https://github.com/adaptivecomputing/torque/archive/6.0.1.tar.gz'
 # Slurm software
 default['cfncluster']['slurm']['version'] = '15-08-8-1'
 default['cfncluster']['slurm']['url'] = 'https://github.com/SchedMD/slurm/archive/slurm-15-08-8-1.tar.gz'


### PR DESCRIPTION
This enables several enhancements and bug fixes listed in http://www.adaptivecomputing.com/resources/docs/torque/6-0-1/torqueReleaseNotes6.0.1.pdf . Torque 6x is a recent verison, and is considered relatively unstable compared to the previous versions. So, I encourage frequent updates.

Among which, following are the issues resolved in 6.0.1 which seems critical:

> Down/offline nodes caused TORQUE to not online elastic nodes. pbs_
server is now able to bring up new nodes even when there are nodes in
the system that are down or offline. (TRQ-3066)

> Memory calculation issues reported when cgroups enabled and -l
vmem|pmem|mem are used. (TRQ-3499)

