### PR TITLE
Sftp: Correcting sftp subsystem path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,7 +52,7 @@ default['openssh']['server']['password_authentication'] = 'no'
 default['openssh']['server']['gssapi_authentication'] = 'yes'
 default['openssh']['server']['gssapi_clean_up_credentials'] = 'yes'
 default['openssh']['server']['x11_forwarding'] = 'yes'
-default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/sftp-server'
+default['openssh']['server']['subsystem'] = 'sftp /usr/libexec/openssh/sftp-server'
 default['openssh']['client']['gssapi_authentication'] = 'yes'
 
 # Platform defaults


### PR DESCRIPTION
sftp-server is located at /usr/libexec/openssh/sftp-server
hence correcting the path in sshd
Fix: https://github.com/awslabs/cfncluster/issues/169

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>