### PR TITLE
I3/F1 instance store not automatically mounted at /scratch

### DIFF
--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -27,7 +27,11 @@ function setup_ephemeral_drives () {
   RC=0
   mkdir -p ${cfn_ephemeral_dir} || RC=1
   chmod 1777 ${cfn_ephemeral_dir} || RC=1
-  MAPPING=$(/usr/bin/ec2-metadata -b | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')
+  if ls /dev/nvme* >& /dev/null; then
+    MAPPING=$(ls /dev/disk/by-id/ |& grep Instance_Storage | grep nvme)
+  else
+    MAPPING=$(/usr/bin/ec2-metadata -b | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')
+  fi
   NUM_DEVS=0
   for m in $MAPPING; do
     umount /dev/${m} >/dev/null 2>&1


### PR DESCRIPTION
Fixes https://github.com/awslabs/cfncluster/issues/195
Instance metadata (IMDS) is not correct in I3/F1 instances.
Hence use nvme* instead of IMDS for finding available drives

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

=== Testing ===
Creating cookbook tarball locally 

version=$(grep version metadata.rb|awk '{print $2}'| tr -d \')

# Create cookbook archive tarball and md5
git archive --format tar --prefix="cfncluster-cookbook-${version}/" HEAD | gzip > cfncluster-cookbook-${version}.tgz
md5sum cfncluster-cookbook-${version}.tgz > cfncluster-cookbook-${version}.md5

create cfncluster overriding custom_chef_cookbook

Tested cfncluster create with f1 type.

 ls -1 /dev/disk/by-id/ |& grep Instance_Storage | grep nvme
nvme-Amazon_EC2_NVMe_Instance_Storage_AWS1606325A3DA70E135-ns-1
nvme-Amazon_EC2_NVMe_Instance_Storage_AWS19F869596ADABA948-ns-1
nvme-Amazon_EC2_NVMe_Instance_Storage_AWS6606325A3DA70E135-ns-1
nvme-Amazon_EC2_NVMe_Instance_Storage_AWS69F869596ADABA948-ns-1

[ec2-user@ip ~]$ cd /scratch/
[ec2-user@ip scratch]$ ls
[ec2-user@ip scratch]$ ls -lrt
total 0
