### PR TITLE
Fixes to Gemfile and travis configuration to unblock testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
-  - 2.1.5 
+  - 2.3.1
+before_install:
+  - wget https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_x86_64.deb
+  - sudo dpkg -i vagrant_2.0.0_x86_64.deb
 install: bundle install --without aws
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ group :style do
 end
 
 group :test do
-  gem 'test-kitchen'
-  gem 'kitchen-vagrant'
+  gem 'test-kitchen', '~> 1.13.2'
+  gem 'kitchen-vagrant', '~> 1.1.0'
   gem 'chefspec', '~> 4.0'
 end
 


### PR DESCRIPTION
- Do a native install of vagrant to satisfy kitchen-vagrant
- Use at least v1.13.2 of test-kitchen to resolve [a known issue]
  (https://github.com/test-kitchen/test-kitchen/issues/645) and the EOL
  of [Chef's Bintray account that affects mixlib](https://discourse.chef.io/t/end-of-life-announcement-for-chef-software-inc-s-bintray-account/9807).
- Use v2.3.1 of Ruby to keep the dependencies happy

While these changes unblock the Travis testing, we now need to fix the actual
cookbook issues that cause the failures.

Signed-off-by: Raghu Raja <craghun@amazon.com>