### PR TITLE
Fix Rubocop warnings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ LineLength:
 
 StringLiterals:
   Enabled: false
+
+Style/NumericLiteralPrefix:
+    EnforcedOctalStyle: zero_only

--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,15 @@ source 'https://rubygems.org'
 gem 'berkshelf'
 
 group :style do
+  gem 'foodcritic', '~> 6.0.1'
   gem 'rake', '~> 11.1.1'
   gem 'rubocop', '~> 0.38'
-  gem 'foodcritic', '~> 6.0.1'
 end
 
 group :test do
-  gem 'test-kitchen', '~> 1.13.2'
-  gem 'kitchen-vagrant', '~> 1.1.0'
   gem 'chefspec', '~> 4.0'
+  gem 'kitchen-vagrant', '~> 1.1.0'
+  gem 'test-kitchen', '~> 1.13.2'
 end
 
 group :aws do

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 CfnCluster Cookbook
 ===================
 
+[![Build Status](https://travis-ci.org/awslabs/cfncluster-cookbook.svg?branch=develop)](https://travis-ci.org/awslabs/cfncluster-cookbook)
+
 This repo contains the CfnCluster Chef cookbook used in CfnCluster.

--- a/Rakefile
+++ b/Rakefile
@@ -25,4 +25,4 @@ rescue LoadError
 end
 
 # default tasks are quick, commit tests
-task default: %w(foodcritic rubocop chefspec)
+task default: %w[foodcritic rubocop chefspec]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,17 +64,17 @@ when 'rhel'
 
   case node['platform']
   when 'centos', 'redhat', 'scientific' # ~FC024
-    default['cfncluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+    default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel
                                                 blas-devel fftw-devel libffi-devel openssl-devel dkms mysql-devel libedit-devel
-                                                libical-devel postgresql-devel postgresql-server sendmail)
+                                                libical-devel postgresql-devel postgresql-server sendmail]
     if node['platform_version'].to_i >= 7
-      default['cfncluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+      default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                   libXmu-devel hwloc-devel libdb-devel tcl-devel automake autoconf pyparted libtool
                                                   httpd boost-devel redhat-lsb mlocate lvm2 mpich-devel openmpi-devel R atlas-devel
                                                   blas-devel fftw-devel libffi-devel openssl-devel dkms mariadb-devel libedit-devel
-                                                  libical-devel postgresql-devel postgresql-server sendmail libxml2-devel)
+                                                  libical-devel postgresql-devel postgresql-server sendmail libxml2-devel]
     end
     if node['platform'] == 'centos' && node['platform_version'].to_i >= 6 && node['platform_version'].to_i < 7
       default['cfncluster']['kernel_devel_pkg']['name'] = "kernel-lt-devel"
@@ -87,11 +87,11 @@ when 'rhel'
     end
 
   when 'amazon'
-    default['cfncluster']['base_packages'] = %w(vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
+    default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh openssl-devel ncurses-devel pam-devel net-tools openmotif-devel
                                                 libXmu-devel hwloc-devel db4-devel tcl-devel automake autoconf pyparted libtool
                                                 httpd boost-devel redhat-lsb mlocate mpich-devel openmpi-devel R atlas-devel fftw-devel
                                                 libffi-devel openssl-devel dkms mysql-devel libedit-devel postgresql-devel postgresql-server
-                                                sendmail cmake byacc)
+                                                sendmail cmake byacc]
   end
 
   default['cfncluster']['ganglia']['apache_user'] = 'apache'
@@ -104,11 +104,11 @@ when 'rhel'
 
 when 'debian'
   default['openssh']['server']['subsystem'] = 'sftp internal-sftp'
-  default['cfncluster']['base_packages'] = %w(vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
+  default['cfncluster']['base_packages'] = %w[vim ksh tcsh zsh libssl-dev ncurses-dev libpam-dev net-tools libhwloc-dev dkms
                                               tcl-dev automake autoconf python-parted libtool librrd-dev libapr1-dev libconfuse-dev
-                                              apache2 libboost-dev libdb-dev tcsh libssl-dev  libncurses5-dev libpam0g-dev libxt-dev
+                                              apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
-                                              r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev) 
+                                              r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev]
   default['cfncluster']['kernel_devel_pkg']['name'] = "linux-image-extra"
   default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'

--- a/recipes/_compute_base_config.rb
+++ b/recipes/_compute_base_config.rb
@@ -31,7 +31,7 @@ mount node['cfncluster']['cfn_shared_dir'] do
   device "#{nfs_master}:#{node['cfncluster']['cfn_shared_dir']}"
   fstype 'nfs'
   options 'hard,intr,noatime,vers=3,_netdev'
-  action [:mount, :enable]
+  action %i[mount enable]
 end
 
 # Mount /home over NFS
@@ -39,7 +39,7 @@ mount '/home' do
   device "#{nfs_master}:/home"
   fstype 'nfs'
   options 'hard,intr,noatime,vers=3,_netdev'
-  action [:mount, :enable]
+  action %i[mount enable]
 end
 
 # Configure Ganglia
@@ -52,7 +52,7 @@ end
 
 service node['cfncluster']['ganglia']['gmond_service'] do
   supports restart: true
-  action [:enable, :restart]
+  action %i[enable restart]
 end
 
 # Setup cluster user

--- a/recipes/_compute_sge_config.rb
+++ b/recipes/_compute_sge_config.rb
@@ -19,7 +19,7 @@ mount '/opt/sge' do
   device "#{nfs_master}:/opt/sge"
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
-  action [:mount, :enable]
+  action %i[mount enable]
 end
 
 # Setup SGE

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -19,7 +19,7 @@ mount '/opt/slurm' do
   device "#{nfs_master}:/opt/slurm"
   fstype "nfs"
   options 'hard,intr,noatime,vers=3,_netdev'
-  action [:mount, :enable]
+  action %i[mount enable]
 end
 
 cookbook_file '/etc/systemd/system/slurmd.service' do
@@ -33,5 +33,5 @@ end
 
 service "slurm" do
   supports restart: false
-  action [:enable]
+  action %i[enable]
 end

--- a/recipes/_compute_torque_config.rb
+++ b/recipes/_compute_torque_config.rb
@@ -33,5 +33,5 @@ end
 # Enable and start pbs_mom service
 service "pbs_mom" do
   supports restart: true
-  action [:enable, :restart]
+  action %i[enable restart]
 end

--- a/recipes/_ec2_udev_rules.rb
+++ b/recipes/_ec2_udev_rules.rb
@@ -43,5 +43,5 @@ end
 
 service "ec2blkdev" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end

--- a/recipes/_ganglia_install.rb
+++ b/recipes/_ganglia_install.rb
@@ -40,7 +40,7 @@ when "redhat", "centos", "amazon", "scientific" # ~FC024
     user 'root'
     group 'root'
     cwd Chef::Config[:file_cache_path]
-    code <<-EOF
+    code <<-GANGLIA
       tar xf #{ganglia_tarball}
       cd monitor-core-#{node['cfncluster']['ganglia']['version']}
       ./bootstrap
@@ -51,7 +51,7 @@ when "redhat", "centos", "amazon", "scientific" # ~FC024
       CORES=$(grep processor /proc/cpuinfo | wc -l)
       make -j $CORES
       make install
-    EOF
+    GANGLIA
     # TODO: Fix, so it works for upgrade
     creates '/usr/sbin/gmetad'
   end
@@ -93,11 +93,11 @@ when "redhat", "centos", "amazon", "scientific" # ~FC024
     user 'root'
     group 'root'
     cwd Chef::Config[:file_cache_path]
-    code <<-EOF
+    code <<-GANGLIAWEB
       tar xf #{ganglia_web_tarball}
       cd ganglia-web-#{node['cfncluster']['ganglia']['web_version']}
       make install APACHE_USER=#{node['cfncluster']['ganglia']['apache_user']}
-    EOF
+    GANGLIAWEB
     # TODO: Fix, so it works for upgrade
     creates '/usr/share/ganglia-webfrontend/index.php'
   end
@@ -124,10 +124,10 @@ when "redhat", "centos", "amazon", "scientific" # ~FC024
     user 'root'
     group 'root'
     cwd Chef::Config[:file_cache_path]
-    code <<-EOF
+    code <<-GANGLIALICENSE
       cd monitor-core-#{node['cfncluster']['ganglia']['version']}
       cp -v COPYING #{node['cfncluster']['license_dir']}/ganglia/COPYING
-    EOF
+    GANGLIALICENSE
     # TODO: Fix, so it works for upgrade
     creates "#{node['cfncluster']['license_dir']}/ganglia/COPYING"
   end

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -62,10 +62,10 @@ end
 # Add volume to /etc/fstab
 mount node['cfncluster']['cfn_shared_dir'] do
   device dev_path
-  fstype DelayedEvaluator.new { node['cfncluster']['cfn_volume_fs_type'] }
+  fstype DelayedEvaluator.new(node['cfncluster']['cfn_volume_fs_type'])
   options "_netdev"
   pass 0
-  action [:mount, :enable]
+  action %i[mount enable]
 end
 
 # Make sure shared directory permissions are correct
@@ -109,17 +109,17 @@ end
 
 service "gmetad" do
   supports restart: true
-  action [:enable, :restart]
+  action %i[enable restart]
 end
 
 service node['cfncluster']['ganglia']['gmond_service'] do
   supports restart: true
-  action [:enable, :restart]
+  action %i[enable restart]
 end
 
 service node['cfncluster']['ganglia']['httpd_service'] do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 # Setup cluster user
@@ -133,25 +133,25 @@ end
 # Setup SSH auth for cluster user
 bash "ssh-keygen" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
-  code <<-EOH
+  code <<-KEYGEN
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keygen -q -t rsa -f ~/.ssh/id_rsa -N ''\"
-  EOH
+  KEYGEN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/id_rsa") }
 end
 
 bash "copy_and_perms" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
-  code <<-EOH
+  code <<-PERMS
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys2 && chmod 0600 ~/.ssh/authorized_keys2\"
-  EOH
+  PERMS
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/authorized_keys2") }
 end
 
 bash "ssh-keyscan" do
   cwd "/home/#{node['cfncluster']['cfn_cluster_user']}"
-  code <<-EOH
+  code <<-KEYSCAN
     su - #{node['cfncluster']['cfn_cluster_user']} -c \"ssh-keyscan #{node['hostname']} > ~/.ssh/known_hosts && chmod 0600 ~/.ssh/known_hosts\"
-  EOH
+  KEYSCAN
   not_if { ::File.exist?("/home/#{node['cfncluster']['cfn_cluster_user']}/.ssh/known_hosts") }
 end
 

--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -45,14 +45,14 @@ end
 
 service "sgemaster.p6444" do
   supports restart: false
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 bash "add_host_as_master" do
-  code <<-EOH
+  code <<-ADDHOST
     . /opt/sge/default/common/settings.sh
     qconf -as #{node['hostname']}
-  EOH
+  ADDHOST
 end
 
 template '/opt/cfncluster/scripts/publish_pending' do

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -59,7 +59,7 @@ end
 
 service "slurm" do
   supports restart: false
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 template '/opt/cfncluster/scripts/publish_pending' do

--- a/recipes/_master_torque_config.rb
+++ b/recipes/_master_torque_config.rb
@@ -15,10 +15,10 @@
 
 # Run torque.setup
 bash "run-torque-setup" do
-  code <<-EOH
+  code <<-SETUPTORQUE
     . /etc/profile.d/torque.sh
     ./torque.setup root
-  EOH
+  SETUPTORQUE
   cwd '/opt/torque/bin'
 end
 
@@ -34,13 +34,13 @@ end
 # Enable and start munge service
 service "munge" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 # Enable and start pbs_server service
 service "pbs_server" do
   supports restart: true
-  action [:enable, :restart]
+  action %i[enable restart]
 end
 
 # Copy pbs_sched service script
@@ -55,7 +55,7 @@ end
 # Enable and start pbs_sched service
 service "pbs_sched" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 # Add publish_pending to cron

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -40,9 +40,9 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     user 'root'
     group 'root'
     cwd '/tmp'
-    code <<-EOF
+    code <<-NVIDIA
     ./nvidia.run --silent --no-network --dkms
-    EOF
+    NVIDIA
     creates '/usr/bin/nvidia-smi'
   end
 
@@ -59,9 +59,9 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
     user 'root'
     group 'root'
     cwd '/tmp'
-    code <<-EOF
+    code <<-CUDA
     ./cuda.run --silent --toolkit
-    EOF
+    CUDA
     creates '/usr/local/cuda-7.5'
   end
 

--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -19,10 +19,10 @@ when 'rhel'
     package 'python-pip'
     package 'python-devel'
     bash 'update pip and setuptools' do
-      code <<-EOH
+      code <<-PIP
         pip install --upgrade pip==7.1.2
         pip install --upgrade setuptools==18.8
-      EOH
+      PIP
     end
   else
     python_runtime '2' do

--- a/recipes/base_config.rb
+++ b/recipes/base_config.rb
@@ -55,5 +55,5 @@ end
 # Restart supervisord
 service "supervisord" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -16,9 +16,8 @@
 case node['platform_family']
 when 'rhel'
   include_recipe 'yum'
-  if node['platform_version'].to_i < 7
-    include_recipe "yum-epel"
-  end
+  include_recipe "yum-epel" if node['platform_version'].to_i < 7
+
   if node['platform'] == 'redhat'
     execute 'yum-config-manager-rhel' do
       command "yum-config-manager --enable #{node['cfncluster']['rhel']['extra_repo']}"
@@ -65,7 +64,7 @@ python_package 'awscli'
 # TODO: update nfs receipes to stop, disable nfs services
 include_recipe "nfs"
 service "rpcbind" do
-  action [:start, :enable]
+  action %i[start enable]
   supports status: true
   only_if { node['platform_family'] == 'rhel' && node['platform_version'].to_i >= 7 && node['platform'] != 'amazon' }
 end

--- a/recipes/munge_install.rb
+++ b/recipes/munge_install.rb
@@ -34,7 +34,7 @@ bash 'make install' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-MUNGE
     tar xf #{munge_tarball}
     cd munge-munge-#{node['cfncluster']['munge']['munge_version']}
     ./bootstrap
@@ -42,7 +42,7 @@ bash 'make install' do
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     make install
-  EOF
+  MUNGE
   # TODO: Fix, so it works for upgrade
   creates '/usr/bin/munge'
   not_if "/usr/sbin/munged --version | grep -q munge-#{node['cfncluster']['munge']['munge_version']}"

--- a/recipes/sge_install.rb
+++ b/recipes/sge_install.rb
@@ -31,7 +31,7 @@ bash 'make install' do
   group 'root'
   cwd Chef::Config[:file_cache_path]
   environment 'SGE_ROOT' => '/opt/sge'
-  code <<-EOF
+  code <<-SGE
     tar xf #{sge_tarball}
     cd sge-#{node['cfncluster']['sge']['version']}/source
     CORES=$(grep processor /proc/cpuinfo | wc -l)
@@ -43,7 +43,7 @@ bash 'make install' do
     echo instremote=false >> distinst.private
     gearch=`dist/util/arch`
     echo 'y'| scripts/distinst -local -allall ${gearch}
-  EOF
+  SGE
   # TODO: Fix, so it works for upgrade
   creates '/opt/sge/bin/lx-amd64/sge_qmaster'
 end
@@ -81,10 +81,10 @@ bash 'copy license stuff' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-SGELICENSE
     cd sge-#{node['cfncluster']['sge']['version']}/LICENCES
     cp -v SISSL #{node['cfncluster']['license_dir']}/sge/SISSL
-  EOF
+  SGELICENSE
   # TODO: Fix, so it works for upgrade
   creates "#{node['cfncluster']['license_dir']}/sge/SISSL"
 end

--- a/recipes/slurm_config.rb
+++ b/recipes/slurm_config.rb
@@ -26,7 +26,7 @@ end
 # Enable munge service
 service "munge" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 cookbook_file '/etc/init.d/slurm' do

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -31,14 +31,14 @@ bash 'make install' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-SLURM
     tar xf #{slurm_tarball}
     cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
     ./configure --prefix=/opt/slurm
     CORES=$(grep processor /proc/cpuinfo | wc -l)
     make -j $CORES
     make install
-  EOF
+  SLURM
   # TODO: Fix, so it works for upgrade
   creates '/opt/slurm/bin/srun'
 end
@@ -68,13 +68,13 @@ bash 'copy license stuff' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-SLURMLICENSE
     cd slurm-slurm-#{node['cfncluster']['slurm']['version']}
     cp -v COPYING #{node['cfncluster']['license_dir']}/slurm/COPYING
     cp -v DISCLAIMER #{node['cfncluster']['license_dir']}/slurm/DISCLAIMER
     cp -v LICENSE.OpenSSL #{node['cfncluster']['license_dir']}/slurm/LICENSE.OpenSSL
     cp -v README.rst #{node['cfncluster']['license_dir']}/slurm/README.rst
-  EOF
+  SLURMLICENSE
   # TODO: Fix, so it works for upgrade
   creates "#{node['cfncluster']['license_dir']}/slurm/README.rst"
 end

--- a/recipes/torque_config.rb
+++ b/recipes/torque_config.rb
@@ -48,7 +48,7 @@ end
 # Enable and start trqauthd service
 service "trqauthd" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 # Create the munge key from template
@@ -61,7 +61,7 @@ end
 # Enable munge service
 service "munge" do
   supports restart: true
-  action [:enable, :start]
+  action %i[enable start]
 end
 
 cookbook_file "/etc/profile.d/torque.sh" do

--- a/recipes/torque_install.rb
+++ b/recipes/torque_install.rb
@@ -31,7 +31,7 @@ bash 'make install' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-TORQUE
     tar xf #{torque_tarball}
     cd torque-#{node['cfncluster']['torque']['version']}
     ./autogen.sh
@@ -40,7 +40,7 @@ bash 'make install' do
     make -j $CORES
     make install
     cp -vpR contrib /opt/torque
-  EOF
+  TORQUE
   # Only perform if running version doesn't match desired
   not_if "/opt/torque/bin/pbsnodes --version 2>&1 | grep -q #{node['cfncluster']['torque']['version']}"
   creates "/random/path"
@@ -78,12 +78,12 @@ bash 'copy license stuff' do
   user 'root'
   group 'root'
   cwd Chef::Config[:file_cache_path]
-  code <<-EOF
+  code <<-TORQUEINSTALL
     cd torque-#{node['cfncluster']['torque']['version']}
     cp -v PBS_License.txt #{node['cfncluster']['license_dir']}/torque/PBS_License.txt
     cp -v LICENSE #{node['cfncluster']['license_dir']}/torque/LICENSE
     cp -v README.md #{node['cfncluster']['license_dir']}/torque/README.md
-  EOF
+  TORQUEINSTALL
   # TODO: Fix, so it works for upgrade
   creates "#{node['cfncluster']['license_dir']}/torque/README.md"
 end


### PR DESCRIPTION
- Rubocop warns against using EO* delimiters for heredocs.
  Using more meaningful ones.
- Use percentage notation for symbol arrays
- Force `zero_only` octal style (to allow `mode 0744`, etc.)
- Enumerate Gemfile packages in alphabetical order as expected by rubocop
- Adding Build status to README

Signed-off-by: Raghu Raja <craghun@amazon.com>

---
Down from 58 Rubocop offenses to one minor style issue, but there are no more warnings/errors that cause the build to fail.