### PR TITLE
Update packages during ami building

### DIFF
--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -70,7 +70,8 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update"
+        "sudo apt-get update",
+        "sudo apt-get -y upgrade"
       ]
     },
     {

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -70,7 +70,8 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update"
+        "sudo apt-get update",
+        "sudo apt-get -y upgrade"
       ]
     },
     {


### PR DESCRIPTION
We see build-ami script is failing with ganglia install
on centos 7. As we dig in we found issue is with libEGL.so whose
dependencies are not correctly loaded in centos 7. Hence to fix that
updating packages in all ami building json.

Fixes : https://github.com/awslabs/cfncluster-cookbook/issues/41

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

== Testing == 
./build_ami.sh centos7 us-east-1 private --> successful ( triggered all build now, since it will take a while I am adding PR now and will merge it once all ami are successful built)

1509666781,,ui,message,    amazon-ebs: cfncluster-1.3.2
1509666781,,ui,say,==> amazon-ebs: Stopping the source instance...
1509666782,,ui,say,==> amazon-ebs: Waiting for the instance to stop...
1509666803,,ui,say,==> amazon-ebs: Enabling Enhanced Networking (SR-IOV)...
1509666803,,ui,say,==> amazon-ebs: Enabling Enhanced Networking (ENA)...
1509666803,,ui,say,==> amazon-ebs: Creating the AMI: cfncluster-1.3.2-centos7-hvm-201711022341
1509666803,,ui,message,    amazon-ebs: AMI: ami-aa04afd0
1509666803,,ui,say,==> amazon-ebs: Waiting for AMI to become ready...
1509667117,,ui,say,==> amazon-ebs: Adding tags to AMI (ami-aa04afd0)...
1509667117,,ui,say,==> amazon-ebs: Tagging snapshot: snap-075a6e22b4a7379e8