### PR TITLE
Incrementing cfncluster version to 1.4.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['cfncluster']['sources_dir'] = "#{node['cfncluster']['base_dir']}/source
 default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/scripts"
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 # Python packages
-default['cfncluster']['cfncluster-node-version'] = '1.3.4'
+default['cfncluster']['cfncluster-node-version'] = '1.4.0'
 default['cfncluster']['cfncluster-supervisor-version'] = '3.3.1'
 # URLs to software packages used during install receipes
 # Gridengine software

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures cfncluster'
 long_description 'Installs/Configures cfncluster'
 issues_url 'https://github.com/awslabs/cfncluster-cookbook/issues'
 source_url 'https://github.com/awslabs/cfncluster-cookbook'
-version '1.3.2'
+version '1.4.0'
 
 depends 'build-essential', '~> 8.0.2'
 depends 'poise-python', '~> 1.6.0'

--- a/packer_variables.json
+++ b/packer_variables.json
@@ -1,6 +1,6 @@
 {
-  "cfncluster_version": "1.3.2",
-  "cfncluster_cookbook_version": "1.3.2",
+  "cfncluster_version": "1.4.0",
+  "cfncluster_cookbook_version": "1.4.0",
   "chef_version": "12.19.36",
   "ridley_version": "5.1.0",
   "berkshelf_version": "5.6.4"


### PR DESCRIPTION
Incrementing cookbook version to 1.4.0 and also
referencing cookbook-node version to 1.4.0
Note: we are not changing chef version nor its
packages version

Let me know if we want to upgrade any of this list
` 
 depends 'build-essential', '~> 8.0.2'
 depends 'poise-python', '~> 1.6.0'
 depends 'tar', '~> 2.0.0'
 depends 'selinux', '~> 2.0.0'
 depends 'nfs', '~> 2.4.1'
 depends 'sysctl', '~> 0.10.1'
 depends 'yum', '~> 5.0.1'
 depends 'yum-epel', '~> 2.1.1'
 depends 'openssh', '~> 2.4.1'
 depends 'apt', '~> 6.1.0'
 depends 'hostname', '~> 0.4.2'
 depends 'line', '~> 0.6.3'
`

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>