### PR TITLE
Upgrading packages in base_install chef receipe

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -24,8 +24,14 @@ when 'rhel'
       command "yum-config-manager --enable #{node['cfncluster']['rhel']['extra_repo']}"
     end
   end
+  execute 'yum-update' do
+    command "yum -y update"
+  end
 when 'debian'
   include_recipe 'apt'
+  execute 'apt-upgrade' do
+    command "apt-get update && apt-get -y upgrade"
+  end
 end
 include_recipe "build-essential"
 include_recipe "cfncluster::_setup_python"


### PR DESCRIPTION
Upgrading packages during base_install receipe
execution. As we add upgrade here, we can now
remove packer command on upgrade

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

Confirmed platform_family is correct for amazon linux too
Ref: https://github.com/awslabs/cfncluster-cookbook/blob/cf6c7c287b0effcd4d76f8a884d334086cb4bf89/attributes/default.rb#L59

And tested 
kitchen test centos7-minimal - working
kitchen test amazon-linux is running successful ( need couple of minutes to confirm)