### PR TITLE
Updating amazon linux to latest 2017.09.1

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -18,10 +18,10 @@ provisioner:
   require_chef_omnibus: 12.19.36
 
 platforms:
-  - name: amazon-linux-2017-09
+  - name: amazon-linux-latest
     driver_plugin: ec2
     driver_config:
-      image_id: ami-8c1be5f6
+      image_id: ami-c555e0bf
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:

--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-8c1be5f6",
+      "source_ami" : "ami-c555e0bf",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
New version of amazon linux released today which has
updates on ena 1.4.0, P3 instance support and
security updates

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

Currently testing kitchen test with this ami locally. 