### PR TITLE
Unpin kernel update in rhel platform family

### DIFF
--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -18,10 +18,7 @@ if node['cfncluster']['nvidia']['enabled'] == 'yes'
 
   case node['platform_family']
   when 'rhel'
-    yum_package node['cfncluster']['kernel_devel_pkg']['name'] do
-      version node['cfncluster']['kernel_devel_pkg']['version']
-      allow_downgrade true
-    end
+    yum_package node['cfncluster']['kernel_devel_pkg']['name']
   when 'debian'
     package = "#{node['cfncluster']['kernel_devel_pkg']['name']}-#{node['cfncluster']['kernel_devel_pkg']['version']}"
     apt_package package


### PR DESCRIPTION
We are pinning to specific kernel version in nvidia_install
recepie, but centos6 ami we have is very old and the specific
version of kernel is not available in repository during
downgrade. Hence removing specific kernel version install for rhel
platform family

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>