### PR TITLE
Fix for slurm install.

### DIFF
--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -28,17 +28,15 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   group 'root'
   mode '0755'
   action :create
-  only_if { ::File.exist?('/bin/systemctl') }
+  only_if { node['init_package'] == 'systemd' }
 end
 
-if ::File.exist?('/bin/systemctl') 
+if node['init_package'] == 'systemd' 
   service "slurmd" do
     supports restart: false
     action %i[enable]
   end
-end
-
-if  ! ::File.exist?('/bin/systemctl') 
+else
   service "slurm" do
     supports restart: false
     action %i[enable]

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -31,7 +31,16 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   only_if { ::File.exist?('/bin/systemctl') }
 end
 
-service "slurm" do
-  supports restart: false
-  action %i[enable]
+if ::File.exist?('/bin/systemctl') 
+  service "slurmd" do
+    supports restart: false
+    action %i[enable]
+  end
+end
+
+if  ! ::File.exist?('/bin/systemctl') 
+  service "slurm" do
+    supports restart: false
+    action %i[enable]
+  end
 end

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -57,9 +57,27 @@ cookbook_file '/etc/systemd/system/slurmctld.service' do
   only_if { ::File.exist?('/bin/systemctl') }
 end
 
-service "slurm" do
-  supports restart: false
-  action %i[enable start]
+if ::File.exist?('/bin/systemctl') 
+  service "slurmctld" do
+    supports restart: false
+    action %i[enable start]
+  end
+end
+
+if  ! ::File.exist?('/bin/systemctl') 
+  service "slurm" do
+    supports restart: false
+    action %i[enable start]
+  end
+end
+
+
+directory '/etc/systemd/system' do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  recursive true
+  action :create
 end
 
 template '/opt/cfncluster/scripts/publish_pending' do

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -54,30 +54,19 @@ cookbook_file '/etc/systemd/system/slurmctld.service' do
   group 'root'
   mode '0755'
   action :create
-  only_if { ::File.exist?('/bin/systemctl') }
+  only_if { node['init_package'] == 'systemd' }
 end
 
-if ::File.exist?('/bin/systemctl') 
+if node['init_package'] == 'systemd' 
   service "slurmctld" do
     supports restart: false
     action %i[enable start]
   end
-end
-
-if  ! ::File.exist?('/bin/systemctl') 
+else 
   service "slurm" do
     supports restart: false
     action %i[enable start]
   end
-end
-
-
-directory '/etc/systemd/system' do
-  owner 'root'
-  group 'root'
-  mode '0755'
-  recursive true
-  action :create
 end
 
 template '/opt/cfncluster/scripts/publish_pending' do

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -58,7 +58,7 @@ cookbook_file '/etc/init.d/slurm' do
   group 'root'
   mode '0755'
   action :create
-  only_if { node['platform_family'] == 'debian' && !(::File.exist?('/bin/systemctl')) }
+  only_if { node['platform_family'] == 'debian' && ! node['init_package'] == 'systemd' }
 end
 
 # Copy required licensing files


### PR DESCRIPTION
This was previously breaking during kitchen test, due to slurm service not being found.
We now choose the correct service to enable / start

Signed-off-by: Jordan Cherry <cherryj@amazon.com>