### PR TITLE
Adding _update_packages recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,11 +13,13 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[cfncluster::_update_packages]
       - recipe[cfncluster::default]
     attributes:
 
   - name: default_gpu
     run_list:
+      - recipe[cfncluster::_update_packages]
       - recipe[cfncluster::default]
     attributes:
       cfncluster:

--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -68,7 +68,7 @@
     {
       "type" : "shell",
       "inline" : [
-        "sudo yum -y update && sudo yum -y groupinstall development && sudo yum -y install curl wget"
+        "sudo yum -y groupinstall development && sudo yum -y install curl wget"
       ]
     },
     {

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -70,8 +70,7 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update",
-        "sudo apt-get -y upgrade"
+        "sudo apt-get update"
       ]
     },
     {

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -70,8 +70,7 @@
       "inline" : [
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
-        "sudo apt-get update",
-        "sudo apt-get -y upgrade"
+        "sudo apt-get update"
       ]
     },
     {

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: cfncluster
+# Recipe:: _update_packages
+#
+# Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+case node['platform_family']
+when 'rhel'
+  execute 'yum-update' do
+    command "yum -y update && package-cleanup -y --oldkernels --count=1"
+  end
+when 'debian'
+  execute 'apt-upgrade' do
+    command "apt-get update && apt-get -y upgrade && apt-get autoremove"
+  end
+end
+

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -23,14 +23,8 @@ when 'rhel'
       command "yum-config-manager --enable #{node['cfncluster']['rhel']['extra_repo']}"
     end
   end
-  execute 'yum-update' do
-    command "yum -y update"
-  end
 when 'debian'
   include_recipe 'apt'
-  execute 'apt-upgrade' do
-    command "apt-get update && apt-get -y upgrade"
-  end
 end
 include_recipe "build-essential"
 include_recipe "cfncluster::_setup_python"


### PR DESCRIPTION
We want to move package update from cloudformation
template bootstrap action as it can create different bits over time.
Adding separate recipe and attaching only during kitchen and packer build

This commit reverts packer changes https://github.com/awslabs/cfncluster-cookbook/pull/44

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

Started testing this changes locally. will update the results soon

Packer - alinux: picks up _update_packages
1510098033,,ui,message,    amazon-ebs: Recipe: cfncluster::_update_packages
1510098033,,ui,message,    amazon-ebs: * execute[yum-update] action run[2017-11-07T23:40:33+00:00] INFO: Processing execute[yum-update] action run (cfncluster::_update_packages line 18)
1510098033,,ui,message,    amazon-ebs:
1510098033,,ui,message,    amazon-ebs: [execute] Loaded plugins: priorities%!(PACKER_COMMA) update-motd%!(PACKER_COMMA) upgrade-helper
1510098033,,ui,message,    amazon-ebs: No packages marked for update
1510098033,,ui,message,    amazon-ebs: [2017-11-07T23:40:33+00:00] INFO: execute[yum-update] ran successfully
1510098033,,ui,message,    amazon-ebs: - execute yum -y update

kitchen also picks up _update_packages

Converging 124 resources
       Recipe: cfncluster::_update_packages
         * execute[yum-update] action run[2017-11-07T23:53:05+00:00] INFO: Processing execute[yum-update] action run (cfncluster::_update_packages line 18)
       
           [execute] Loaded plugins: priorities, update-motd, upgrade-helper
              No packages marked for update
       [2017-11-07T23:53:05+00:00] INFO: execute[yum-update] ran successfully
           - execute yum -y update

