### PR TITLE
Update ubuntu ami to latest

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -428,7 +428,7 @@ platforms:
   - name: ubuntu-14-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: ami-2ac4843d
+      image_id: ami-7dce6507
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -489,7 +489,7 @@ platforms:
   - name: ubuntu-16-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: ami-45c18152
+      image_id: ami-da05a4a0
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -19,7 +19,7 @@
       "region" : "us-east-1",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-772aa961",
+      "source_ami" : "ami-7dce6507",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -19,7 +19,7 @@
       "region" : "us-east-1",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-45c18152",
+      "source_ami" : "ami-da05a4a0",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,


### PR DESCRIPTION
Updating ubuntu16.04 and ubuntu14.04 ami
to latest as of today

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

FYI
Ubuntu Server 16.04 LTS (HVM), SSD Volume Type - ami-da05a4a0
Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-7dce6507