### PR TITLE
Updating nvidia driver and moving to cuda9

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,8 +41,8 @@ default['cfncluster']['ganglia']['web_version'] = '3.7.2'
 default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/ganglia-web/archive/3.7.2.tar.gz'
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
-default['cfncluster']['nvidia']['driver_url'] = 'http://us.download.nvidia.com/XFree86/Linux-x86_64/375.66/NVIDIA-Linux-x86_64-375.66.run'
-default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_375.26_linux-run'
+default['cfncluster']['nvidia']['driver_url'] = 'http://us.download.nvidia.com/XFree86/Linux-x86_64/384.98/NVIDIA-Linux-x86_64-384.98.run'
+default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run'
 
 # OpenSSH settings for CfnCluster instances
 default['openssh']['server']['protocol'] = '2'


### PR DESCRIPTION
Updating nvidia driver to latest (384) and moving to cuda 9. 

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>

We will have latest bits with respect to P3 (I will test backward compatibility on G2, G3 and P2 as well once we have final ami build)

We still need NCCL https://developer.nvidia.com/nccl and cuDNN (which can be optional for release) - Both need login to download (https://developer.nvidia.com/nccl/nccl2-download-survey), check with @bwbarrett on this

I am using following AMI as my reference https://aws.amazon.com/marketplace/pp/B076T8RSXY?qid=1510119646103&sr=0-2&ref_=srh_res_product_title