### PR TITLE
GPU: Optionally install kernel-extras

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -109,8 +109,13 @@ when 'debian'
                                               apache2 libboost-dev libdb-dev tcsh libssl-dev libncurses5-dev libpam0g-dev libxt-dev
                                               libmotif-dev libxmu-dev libxft-dev libhwloc-dev man-db lvm2 libmpich-dev libopenmpi-dev
                                               r-base libatlas-dev libblas-dev libfftw3-dev libffi-dev libssl-dev libxml2-dev]
-  default['cfncluster']['kernel_devel_pkg']['name'] = "linux-image-extra"
-  default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
+  if Chef::VersionConstraint.new('< 16.04').include?(node['platform_version'])
+    default['cfncluster']['kernel_devel_pkg']['name'] = "linux-image-extra"
+    default['cfncluster']['kernel_devel_pkg']['version'] = node['kernel']['release']
+  else
+    default['cfncluster']['kernel_devel_pkg']['name'] = ""
+    default['cfncluster']['kernel_devel_pkg']['version'] = ""
+  end
   default['cfncluster']['ganglia']['apache_user'] = 'www-data'
   default['cfncluster']['ganglia']['gmond_service'] = 'ganglia-monitor'
   default['cfncluster']['ganglia']['httpd_service'] = 'apache2'

--- a/recipes/_nvidia_install.rb
+++ b/recipes/_nvidia_install.rb
@@ -16,12 +16,14 @@
 # Only run if node['cfncluster']['nvidia']['enabled'] = 'yes'
 if node['cfncluster']['nvidia']['enabled'] == 'yes'
 
-  case node['platform_family']
-  when 'rhel'
-    yum_package node['cfncluster']['kernel_devel_pkg']['name']
-  when 'debian'
-    package = "#{node['cfncluster']['kernel_devel_pkg']['name']}-#{node['cfncluster']['kernel_devel_pkg']['version']}"
-    apt_package package
+  if node['cfncluster']['kernel_devel_pkg']['name'] != ""
+    case node['platform_family']
+    when 'rhel'
+      yum_package node['cfncluster']['kernel_devel_pkg']['name']
+    when 'debian'
+      package = "#{node['cfncluster']['kernel_devel_pkg']['name']}-#{node['cfncluster']['kernel_devel_pkg']['version']}"
+      apt_package package
+    end
   end
 
   # Get NVIDIA run file


### PR DESCRIPTION
With Ubuntu 16.04, the AWS kernel includes all the GPU bits, no
need for the extras package.  So make it optional.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>