### PR TITLE
Fix kernel-lt and ENA support in CentOS 6 base AMI

### DIFF
--- a/centos-upgrade-first-stage.sh
+++ b/centos-upgrade-first-stage.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# Script to run the first stage (everything through rebooting to flip into
+# the new kernel) for upgrading the CentOS AMIs from the imported version
+# to the latest in that major release series.
+#
+# By the time this script was written, CentOS 7.4 had shipped, which
+# includes ENA driver by default.  CentOS 6, being ancient, won't
+# include such upgrades, so we do that after upgrade (actually,
+# centos-upgrade-second-stage does that, so that we don't have to
+# guess at what the new default kernel version is).
+#
+
+if test "`sed -n '/CentOS release 6\..*/p' /etc/centos-release`" != ""; then
+    is_centos6=1
+else
+    is_centos6=0
+fi
+
+if test $is_centos6 -eq 1 -a "`/sbin/lsmod | grep ena`" != "" ; then
+    echo "This script is lazy and can not be run on instances which"
+    echo "use ENA for networking.  Either update the script or use"
+    echo "a non-ENA instance type."
+    echo "***** Aborting now *****"
+    exit 1
+fi
+
+if test $is_centos6 -eq 1; then
+    # CfnCluster CentOS AMIs have always shipped with the elrepo -lt
+    # kernel as the default, but it appears to have been set as the
+    # default by hand in grub.conf.  Make the -lt kernel the default
+    # in systconfig, so yum upgrade won't revert the default kernel
+    # back to the 2.6.32 default kernel.
+    echo "Setting kernel-lt as default kernel series"
+    sudo /bin/sed -r -i -e 's/^DEFAULTKERNEL=kernel$/DEFAULTKERNEL=kernel-lt/' /etc/sysconfig/kernel || exit $?
+fi
+
+# Upgrade everything!
+echo "Running upgrades!"
+sudo yum -y upgrade
+
+echo "Update Complete.  Rebooting."
+# sleep for 30 seconds to make sure packer doesn't try to run the next
+# step before the reboot happens
+sudo reboot ; sleep 30

--- a/centos-upgrade-second-stage.sh
+++ b/centos-upgrade-second-stage.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Script to run the second stage (everything after rebooting into the
+# newest kernel) for upgrading the CenOS AMIs from the imported
+# version to the latest in that major release series.
+#
+
+if test "`sed -n '/CentOS release 6\..*/p' /etc/centos-release`" != ""; then
+    is_centos6=1
+else
+    is_centos6=0
+fi
+
+if test $is_centos6 -eq 1; then
+    # upgrade to latest ENA
+    echo "Upgrading ENA module"
+
+    echo "Getting ENA source"
+    git clone https://github.com/amzn/amzn-drivers.git
+    cd amzn-drivers
+    git checkout ena_linux_1.3.0
+
+    echo "Building ENA source"
+    cd kernel/linux/ena
+    make
+
+    echo "Installing ENA source"
+    sudo cp ena.ko /lib/modules/`uname -r`/weak-updates/.
+    sudo depmod -a
+
+fi
+
+echo "Cleaning out old kernels"
+sudo package-cleanup -y --oldkernels --count=1
+
+echo "Cleaning up filesystem"
+sudo rm -rf /tmp/* /var/tmp/* /var/log/* /etc/ssh/ssh_host*
+sudo rm -rf /root/* /root/.ssh /root/.history /root/.bash_history
+sudo rm -rf ~/* ~/.ssh ~/.history ~/.bash_history ~/.cache
+
+echo "All done!"

--- a/packer_update_centos_base.json
+++ b/packer_update_centos_base.json
@@ -34,18 +34,11 @@
     {
       "type" : "shell",
       "expect_disconnect" : true,
-      "inline" : [
-        "sudo yum -y upgrade",
-        "echo Update Complete.  Rebooting.",
-        "sudo reboot ; sleep 30"
-      ]
+      "script" : "centos-upgrade-first-stage.sh"
     },
     {
       "type" : "shell",
-      "inline" : [
-        "sudo package-cleanup -y --oldkernels --count=1",
-        "sudo rm -rf /tmp/* /var/tmp/* /var/log/* /etc/ssh/ssh_host* /root/* /root/.ssh /root/.history /root/.bash_history ~/.history ~/.bash_history ~/.cache ~/.ssh/authorized_keys ~/amzn-drivers-master"
-      ]
+      "script" : "centos-upgrade-second-stage.sh"
     }
   ]
 }


### PR DESCRIPTION
The previous packer scripts to update the CentOS base
AMIs broke CentOS 6 in two critical ways.  First, the
kernel was changed from 3.10.x (the kernel-lt packages)
to 2.6.32 (the kernel packages).  Second, I forgot to
build ENA support into the updated kernel.  This patch
addresses both issues.

First, the default kernel in /etc/sysconfig/kernel is
changed from kernel to kernel-lt, which means that any
future yum upgrades will leave the kernel-lt version as
the default in grub (someone must have been updating
grub by hand previously).  So the 3.10/2.6.32 problem
should be fixed going forward.

Second, we now build the ENA kernel module after the
reboot step, so that we make sure we build the kernel
module for the new version of the kernel.  It might
be better to build the ENA kernel module for all
installed kernel versions (ie, include the 2.6.32
module as well), but I have mixed feelings given the
limited testing and decided to skip that step for now.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>