### PR TITLE
amis: Use CentOS community AMIs as base

### DIFF
--- a/centos-upgrade-second-stage.sh
+++ b/centos-upgrade-second-stage.sh
@@ -12,9 +12,11 @@ else
     is_centos6=0
 fi
 
-if test $is_centos6 -eq 1; then
+if ! sudo modprobe ena; then
+    set -e
+
     # upgrade to latest ENA
-    echo "Upgrading ENA module"
+    echo "Installing ENA module"
 
     echo "Getting ENA source"
     git clone https://github.com/amzn/amzn-drivers.git
@@ -22,13 +24,17 @@ if test $is_centos6 -eq 1; then
     git checkout ena_linux_1.3.0
 
     echo "Building ENA source"
+    BUILD_KERNEL=`uname -r`
     cd kernel/linux/ena
     make
 
     echo "Installing ENA source"
-    sudo cp ena.ko /lib/modules/`uname -r`/weak-updates/.
+    sudo make -C /lib/modules/${BUILD_KERNEL}/build M=`pwd` modules_install
     sudo depmod -a
 
+    set +e
+else
+    echo "Not installing ENA module"
 fi
 
 echo "Cleaning out old kernels"

--- a/centos6.elrepo.repo
+++ b/centos6.elrepo.repo
@@ -1,0 +1,54 @@
+### Name: ELRepo.org Community Enterprise Linux Repository for el6
+### URL: http://elrepo.org/
+
+[elrepo]
+name=ELRepo.org Community Enterprise Linux Repository - el6
+baseurl=http://elrepo.org/linux/elrepo/el6/$basearch/
+	http://mirrors.coreix.net/elrepo/elrepo/el6/$basearch/
+	http://mirror.rackspace.com/elrepo/elrepo/el6/$basearch/
+	http://repos.lax-noc.com/elrepo/elrepo/el6/$basearch/
+	http://mirror.ventraip.net.au/elrepo/elrepo/el6/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo.el6
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+protect=0
+
+[elrepo-testing]
+name=ELRepo.org Community Enterprise Linux Testing Repository - el6
+baseurl=http://elrepo.org/linux/testing/el6/$basearch/
+	http://mirrors.coreix.net/elrepo/testing/el6/$basearch/
+	http://mirror.rackspace.com/elrepo/testing/el6/$basearch/
+	http://repos.lax-noc.com/elrepo/testing/el6/$basearch/
+	http://mirror.ventraip.net.au/elrepo/testing/el6/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-testing.el6
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+protect=0
+
+[elrepo-kernel]
+name=ELRepo.org Community Enterprise Linux Kernel Repository - el6
+baseurl=http://elrepo.org/linux/kernel/el6/$basearch/
+	http://mirrors.coreix.net/elrepo/kernel/el6/$basearch/
+	http://mirror.rackspace.com/elrepo/kernel/el6/$basearch/
+	http://repos.lax-noc.com/elrepo/kernel/el6/$basearch/
+	http://mirror.ventraip.net.au/elrepo/kernel/el6/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-kernel.el6
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+protect=0
+
+[elrepo-extras]
+name=ELRepo.org Community Enterprise Linux Extras Repository - el6
+baseurl=http://elrepo.org/linux/extras/el6/$basearch/
+	http://mirrors.coreix.net/elrepo/extras/el6/$basearch/
+	http://mirror.rackspace.com/elrepo/extras/el6/$basearch/
+	http://repos.lax-noc.com/elrepo/extras/el6/$basearch/
+	http://mirror.ventraip.net.au/elrepo/extras/el6/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-extras.el6
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
+protect=0

--- a/packer_update_centos_base.json
+++ b/packer_update_centos_base.json
@@ -7,7 +7,7 @@
       "type": "amazon-ebs",
       "name" : "CentOS 6",
       "region": "us-east-1",
-      "source_ami": "ami-b7c484a0",
+      "source_ami": "ami-500d8546",
       "instance_type": "t2.micro",
       "ssh_username": "centos",
       "ssh_pty" : true,
@@ -20,7 +20,7 @@
       "type": "amazon-ebs",
       "name" : "CentOS 7",
       "region": "us-east-1",
-      "source_ami": "ami-9dc3838a",
+      "source_ami": "ami-ae7bfdb8",
       "instance_type": "t2.micro",
       "ssh_username": "centos",
       "ssh_pty" : true,
@@ -31,6 +31,11 @@
     }
   ],
   "provisioners" : [
+    {
+      "type": "file",
+      "source": "centos6.elrepo.repo",
+      "destination": "/tmp/centos6.elrepo.repo"
+    },
     {
       "type" : "shell",
       "expect_disconnect" : true,


### PR DESCRIPTION
Use the CentOS-provided community AMIs as the base for our
CentOS AMIs, rather than our home-imported base AMI.  We
still update the AMIs to the latest release as a seperate
step from building the final images out of expediency for the
next release.

These packages configure the AMIs to match what the imported
base AMIs do.  They configure epel on both AMIs and elrepo
on CentOS 6 (although only the kernel package from elrepo).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>