### PR TITLE
amis: Fix CentOS base AMI dependencies

### DIFF
--- a/centos-upgrade-first-stage.sh
+++ b/centos-upgrade-first-stage.sh
@@ -64,7 +64,17 @@ echo "Installing basic packages"
 sudo yum -y groupinstall development
 sudo yum -y install git yum-utils
 
+if test $is_centos6 -eq 1; then
+    sudo yum -y install python-pip
+    sudo pip install awscli --upgrade
+else
+    sudo yum -y install python-pip python-wheel awscli
+fi
+
 set +e
+
+echo "Disabling SELinux"
+sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
 
 echo "Update Complete.  Rebooting."
 # sleep for 30 seconds to make sure packer doesn't try to run the next


### PR DESCRIPTION
The Chef recipes expect pip and awscli to be installed, so do so.
They also expect the base AMIs to have SELinux disabled, so disable
SELinux, since CentOS community AMIs apparently enable it by
default.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>