### PR TITLE
Update CentOS 6 / CentOS 7 AMI list

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -82,7 +82,7 @@ platforms:
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-9ff841e5
+      image_id: ami-a0f843da
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -143,7 +143,7 @@ platforms:
   - name: centos-7-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-6dff4617
+      image_id: ami-f9fa4183
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-9ff841e5",
+      "source_ami" : "ami-a0f843da",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-6dff4617",
+      "source_ami" : "ami-f9fa4183",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
Once again, update the CentOS 6 and CentOS 7 AMIs, this time to
include awscli and turn off SELinux.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>