### PR TITLE
amis: Fix kernel parameters for CentOS6 and CentOS 7

### DIFF
--- a/centos-upgrade-first-stage.sh
+++ b/centos-upgrade-first-stage.sh
@@ -76,6 +76,13 @@ set +e
 echo "Disabling SELinux"
 sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
 
+# Updating GRUB to blacklist the neuvou driver (so the nVidia driver can
+# install) and turning off ifnames, because a bunch of the scripts expect
+# to find eth0.  Should handle the eth naming better, but that's todo.
+echo "Updating Grub command line"
+sudo /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
+sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+
 echo "Update Complete.  Rebooting."
 # sleep for 30 seconds to make sure packer doesn't try to run the next
 # step before the reboot happens


### PR DESCRIPTION
Chef recipes expect the neuvou driver to be blacklisted and
old-style ethernet names (ethX) to be used.  Add kernel
parameters to the centos base ami update script to make
that so.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>