### PR TITLE
Reverting centos6 ami

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -82,7 +82,7 @@ platforms:
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-a0f843da
+      image_id: ami-9ff841e5
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-a0f843da",
+      "source_ami" : "ami-9ff841e5",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
We seeing issues with centos6 community ami (doesn't
resize properly). As we work on fixing the issue, I am
reverting ami so we move forward with old ami

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>