### PR TITLE
Fixing Ubunut interface naming scheme.

### DIFF
--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -146,6 +146,13 @@
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
       ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"net.ifnames=0 biosdevname=0\"/' /etc/default/grub",
+        "sudo grub-mkconfig -o /boot/grub/grub.cfg"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adding shell commands to force ubuntu16 to revert to old name of
interface naming, as we expect it to be in the ethn format.  Built ami by hand and confirmed
interface naming.

Signed-off-by: Jordan Cherry cherryj@amazon.com