### PR TITLE
Updating centos7 ami (which has latest script update)

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -143,7 +143,7 @@ platforms:
   - name: centos-7-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-f9fa4183
+      image_id: ami-01098c7b
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-f9fa4183",
+      "source_ami" : "ami-01098c7b",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
Updating centos7 ami which has latest nvidia driver
fix (https://github.com/awslabs/cfncluster-cookbook/pull/68/files) made by Brian 

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>