### PR TITLE
Upgrading rubocop due to security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'berkshelf'
 group :style do
   gem 'foodcritic', '~> 6.0.1'
   gem 'rake', '~> 11.1.1'
-  gem 'rubocop', '~> 0.38'
+  gem 'rubocop', '~> 0.49'
 end
 
 group :test do

--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -31,7 +31,7 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   only_if { node['init_package'] == 'systemd' }
 end
 
-if node['init_package'] == 'systemd' 
+if node['init_package'] == 'systemd'
   service "slurmd" do
     supports restart: false
     action %i[enable]

--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -62,7 +62,7 @@ end
 # Add volume to /etc/fstab
 mount node['cfncluster']['cfn_shared_dir'] do
   device dev_path
-  fstype DelayedEvaluator.new{node['cfncluster']['cfn_volume_fs_type']}
+  fstype DelayedEvaluator.new { node['cfncluster']['cfn_volume_fs_type'] }
   options "_netdev"
   pass 0
   action %i[mount enable]

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -57,12 +57,12 @@ cookbook_file '/etc/systemd/system/slurmctld.service' do
   only_if { node['init_package'] == 'systemd' }
 end
 
-if node['init_package'] == 'systemd' 
+if node['init_package'] == 'systemd'
   service "slurmctld" do
     supports restart: false
     action %i[enable start]
   end
-else 
+else
   service "slurm" do
     supports restart: false
     action %i[enable start]

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -23,4 +23,3 @@ when 'debian'
     command "apt-get update && apt-get -y upgrade && apt-get autoremove"
   end
 end
-

--- a/recipes/slurm_install.rb
+++ b/recipes/slurm_install.rb
@@ -58,7 +58,7 @@ cookbook_file '/etc/init.d/slurm' do
   group 'root'
   mode '0755'
   action :create
-  only_if { node['platform_family'] == 'debian' && ! node['init_package'] == 'systemd' }
+  only_if { node['platform_family'] == 'debian' && !node['init_package'] == 'systemd' }
 end
 
 # Copy required licensing files


### PR DESCRIPTION
upgrading rubocop to 0.49 due to security vulnerability, also fixing
minor style issue

Security vulnerability : https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>