### PR TITLE
Use the realpath of the NVMe devices instead of the symlinks.

### DIFF
--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -28,8 +28,10 @@ function setup_ephemeral_drives () {
   mkdir -p ${cfn_ephemeral_dir} || RC=1
   chmod 1777 ${cfn_ephemeral_dir} || RC=1
   if ls /dev/nvme* >& /dev/null; then
+    IS_NVME=1
     MAPPING=$(realpath --relative-to=/dev/ -P  /dev/disk/by-id/nvme*Instance_Storage*)
   else
+    IS_NVME=0
     MAPPING=$(/usr/bin/ec2-metadata -b | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')
   fi
   NUM_DEVS=0
@@ -46,11 +48,16 @@ function setup_ephemeral_drives () {
     for d in $DEVS; do
       d=/dev/${d}
       dd if=/dev/zero of=${d} bs=32k count=1 || RC=1
-      parted -s ${d} mklabel msdos || RC=1
+      parted -s ${d} mklabel gpt || RC=1
       parted -s ${d} || RC=1
       parted -s -a optimal ${d} mkpart primary 1MB 100% || RC=1
+      partprobe
       parted -s ${d} set 1 lvm on || RC=1
-      PARTITIONS="${d}1 $PARTITIONS"
+      if [ $IS_NVME -eq 1 ]; then
+        PARTITIONS="${d}p1 $PARTITIONS"
+      else
+        PARTITIONS="${d}1 $PARTITIONS"
+      fi
     done
     if [ $RC -ne 0 ]; then
       error_exit "Failed to detect and/or partition ephemeral devices."
@@ -61,7 +68,7 @@ function setup_ephemeral_drives () {
 
     # Setup LVM
     RC=0
-    pvcreate $PARTITIONS || RC=1
+    pvcreate -y $PARTITIONS || RC=1
     vgcreate vg.01 $PARTITIONS || RC=1
     lvcreate -i $NUM_DEVS -I 64 -l 100%FREE -n lv_ephemeral vg.01 || RC=1
     if [ "$cfn_encrypted_ephemeral" == "true" ]; then

--- a/files/default/setup-ephemeral-drives.sh
+++ b/files/default/setup-ephemeral-drives.sh
@@ -28,7 +28,7 @@ function setup_ephemeral_drives () {
   mkdir -p ${cfn_ephemeral_dir} || RC=1
   chmod 1777 ${cfn_ephemeral_dir} || RC=1
   if ls /dev/nvme* >& /dev/null; then
-    MAPPING=$(ls /dev/disk/by-id/ |& grep Instance_Storage | grep nvme)
+    MAPPING=$(realpath --relative-to=/dev/ -P  /dev/disk/by-id/nvme*Instance_Storage*)
   else
     MAPPING=$(/usr/bin/ec2-metadata -b | grep ephemeral | awk '{print $2}' | sed 's/sd/xvd/')
   fi


### PR DESCRIPTION
The rest of the setup-ephemeral-disks.sh scripts functions with the assumption
that $MAPPING refers to a block device in /dev, but when using the udev
symlink for instance store devices, it breaks (for eg., it ends up looking for
/dev/nvme-Amazon_EC2_NVMe_Instance_Storage_AWSxxx, which would not exist).

Signed-off-by: Raghu Raja <craghun@amazon.com>


Use the right prefix when partitioning NVMe devices.

Traditional block device partitions take a label of the form `/dev/sd*<n>` for a
partition 'n', while NVMe devices take the label `/dev/nvme*p<n>`.

Signed-off-by: Raghu Raja <craghun@amazon.com