### PR TITLE
Remove Python version dependency in cfncluster-ebsnvme-id.

### DIFF
--- a/files/default/cfncluster-ebsnvme-id
+++ b/files/default/cfncluster-ebsnvme-id
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # Copyright (C) 2017 Amazon.com, Inc. or its affiliates.
 # All Rights Reserved.


### PR DESCRIPTION
CentOS 6 ships with Python 2.6, while the ebsnvme-id script expects Python 2.7.
The script works fine with v2.6 as well, so making it use whichever interpreter
is available by default on the system.

Signed-off-by: Raghu Raja <craghun@amazon.com>