### PR TITLE
Rescan PCI bus to allow outdated NVMe drivers to discover volumes.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -7,9 +7,19 @@ require 'timeout'
 #
 def wait_for_block_dev(path)
   Timeout.timeout(60) do
-    sleep(1) until ::File.blockdev?(path)
+    until ::File.blockdev?(path)
+      sleep(5)
+      rescan_pci()
+    end
     Chef::Log.debug("device ${path} not ready - sleeping 1s")
   end
+end
+
+#
+# Rescan the PCI bus to discover newly added volumes.
+#
+def rescan_pci()
+  Mixlib::ShellOut.new("echo 1 > /sys/bus/pci/rescan").run_command
 end
 
 #


### PR DESCRIPTION
With CentOS 6 AMIs that have an outdated NVMe driver, we need to force a rescan
of the PCI bus after attaching an EBS volume so the driver can attach to it. The
rescan should not be harmful for other platforms, so triggering it
unconditionally. Implementing it here as the rescan has to be done after the
boto call has been made to attach a volume (from attachVolume.py) while polling
for the device so the rescan can cause our udev rule to kick in for
/dev/disk/by-ebs-volumeid.

Signed-off-by: Raghu Raja <craghun@amazon.com>