### PR TITLE
Modify Slurm service files permission & restrict slurm init.d file

### DIFF
--- a/recipes/_compute_slurm_config.rb
+++ b/recipes/_compute_slurm_config.rb
@@ -26,7 +26,7 @@ cookbook_file '/etc/systemd/system/slurmd.service' do
   source 'slurmd.service'
   owner 'root'
   group 'root'
-  mode '0755'
+  mode '0644'
   action :create
   only_if { node['init_package'] == 'systemd' }
 end

--- a/recipes/_master_slurm_config.rb
+++ b/recipes/_master_slurm_config.rb
@@ -52,7 +52,7 @@ cookbook_file '/etc/systemd/system/slurmctld.service' do
   source 'slurmctld.service'
   owner 'root'
   group 'root'
-  mode '0755'
+  mode '0644'
   action :create
   only_if { node['init_package'] == 'systemd' }
 end

--- a/recipes/slurm_config.rb
+++ b/recipes/slurm_config.rb
@@ -34,6 +34,7 @@ cookbook_file '/etc/init.d/slurm' do
   owner 'root'
   group 'root'
   mode '0755'
+  only_if { node['init_package'] != 'systemd' }
 end
 
 # case node['cfncluster']['cfn_node_type']


### PR DESCRIPTION
1)  Modifying permission of slurm service files   -> Removing executable permission for both slurmctld and slurmd service files
2) Don't copy slurm init.d file if it's systemd

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>