### PR TITLE
Referring cfncluster-node 1.4.2 in cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Major new features/updates:
   - Upgraded Centos 6 AMI
   - Updated to Nvidia driver 384 
   - Updated to CUDA 9
-  - Updated to latest cfncluster-node 1.4.1 
+  - Updated to latest cfncluster-node 1.4.2 
 
 Bug fixes/minor improvements:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['cfncluster']['sources_dir'] = "#{node['cfncluster']['base_dir']}/source
 default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/scripts"
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 # Python packages
-default['cfncluster']['cfncluster-node-version'] = '1.4.1'
+default['cfncluster']['cfncluster-node-version'] = '1.4.2'
 default['cfncluster']['cfncluster-supervisor-version'] = '3.3.1'
 # URLs to software packages used during install receipes
 # Gridengine software


### PR DESCRIPTION
As we bumped cfncluster-node version to 1.4.2, updating
node version references in cookbook

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>