### PR TITLE
Fix interactive dialog during apt-get upgrade

### DIFF
--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -20,6 +20,6 @@ when 'rhel'
   end
 when 'debian'
   execute 'apt-upgrade' do
-    command "apt-get update && apt-get -y upgrade && apt-get autoremove"
+    command "ucf --purge /boot/grub/menu.lst && apt-get update && UCF_FORCE_CONFFNEW=YES apt-get -yq upgrade && apt-get autoremove"
   end
 end


### PR DESCRIPTION
During apt-get upgrade, ubuntu 16.04 getting struck with an interactive dialog stating
a new version of grub/menu.list is available and prompt is to select which version of menu.list to proceed. This is a known issue refer: 
https://devops.stackexchange.com/questions/1139/how-to-avoid-interactive-dialogs-when-running-apt-get-upgrade-y-in-ubuntu-16
https://serverfault.com/questions/645566/a-new-version-of-boot-grub-menu-lst-is-available-when-upgrading-ubuntu-on-an

Tested both ubuntu14 & 16 cookbook
Signed-off-by: Mohan Gandhi <mohgan@amazon.com>