### PR TITLE
Updating to latest alinux ami

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -21,7 +21,7 @@ platforms:
   - name: amazon-linux-latest
     driver_plugin: ec2
     driver_config:
-      image_id: ami-c555e0bf
+      image_id: ami-55ef662f
       block_device_mappings:
         - device_name: /dev/xvda
           ebs:

--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-c555e0bf",
+      "source_ami" : "ami-55ef662f",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
Today we see problem with yum update on alinux.
As we update, we seeing kernel version also bumped.
In order use latest kernel, system requires reboot via chef.
We haven't found proper way to reboot via chef and
continue receipe execution. To move us forward, we are updating to
latest alinux ami.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>