### PR TITLE
Updating ubuntu ami's to latest

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -204,7 +204,7 @@ platforms:
   - name: ubuntu-14-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: ami-7dce6507
+      image_id: ami-c29e1cb8
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -265,7 +265,7 @@ platforms:
   - name: ubuntu-16-04-lts
     driver_plugin: ec2
     driver_config:
-      image_id: ami-da05a4a0
+      image_id: ami-aa2ea6d0
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -19,7 +19,7 @@
       "region" : "us-east-1",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-7dce6507",
+      "source_ami" : "ami-c29e1cb8",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -19,7 +19,7 @@
       "region" : "us-east-1",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-da05a4a0",
+      "source_ami" : "ami-aa2ea6d0",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,


### PR DESCRIPTION
We seeing issue with apt-get upgrade in ubuntu 16.04
One solution to solve user prompt issue is to muck around
with ucf & dpkg options. To move us forward with
confidence, I prefer to simply update ubuntu ami's to latest.
Verified - Kitchen test is happy with ami update.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>