### PR TITLE
post-release: Update to next version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures cfncluster'
 long_description 'Installs/Configures cfncluster'
 issues_url 'https://github.com/awslabs/cfncluster-cookbook/issues'
 source_url 'https://github.com/awslabs/cfncluster-cookbook'
-version '1.4.0'
+version '1.4.1'
 
 depends 'build-essential', '~> 8.0.2'
 depends 'poise-python', '~> 1.6.0'

--- a/packer_variables.json
+++ b/packer_variables.json
@@ -1,6 +1,6 @@
 {
-  "cfncluster_version": "1.4.0",
-  "cfncluster_cookbook_version": "1.4.0",
+  "cfncluster_version": "1.4.1",
+  "cfncluster_cookbook_version": "1.4.1",
   "chef_version": "12.19.36",
   "ridley_version": "5.1.0",
   "berkshelf_version": "5.6.4"


### PR DESCRIPTION
As past of release process we copy cookbook &
template to s3. After the release we should move
forward and should avoid chance of overriding existing
files of this version. Hence its good practice to bump version
immediately after the release

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>