### PR TITLE
Updating the version of cfncluster-node to install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ cfncluster-cookbook CHANGELOG
 
 This file is used to list changes made in each version of the cfncluster cookbook.
 
+1.4.1
+-----
+
+Major new features/updates:
+
+  - Updated to latest cfncluster-node 1.4.3
+
 1.4.0
 -----
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@ default['cfncluster']['sources_dir'] = "#{node['cfncluster']['base_dir']}/source
 default['cfncluster']['scripts_dir'] = "#{node['cfncluster']['base_dir']}/scripts"
 default['cfncluster']['license_dir'] = "#{node['cfncluster']['base_dir']}/licenses"
 # Python packages
-default['cfncluster']['cfncluster-node-version'] = '1.4.2'
+default['cfncluster']['cfncluster-node-version'] = '1.4.3'
 default['cfncluster']['cfncluster-supervisor-version'] = '3.3.1'
 # URLs to software packages used during install receipes
 # Gridengine software


### PR DESCRIPTION
Having pushed a v1.4.3 of cfncluster-node to PyPI, this commit updates the
cookbook to pull the latest version. The version of the cookbook was already
bumped to v1.4.1 after the previous release, hence just adding a CHANGELOG entry
to reflect the update.

Signed-off-by: Raghu Raja <craghun@amazon.com>