### PR TITLE
Refresh the APT repo metadata prior to installing build-essentials.

### DIFF
--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -69,6 +69,14 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo apt-cache search build-essential",
+        "sudo apt-get clean",
+        "sudo apt-get update"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
         "sudo apt-get -y install build-essential curl wget"
       ]
     },

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -69,6 +69,14 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo apt-cache search build-essential",
+        "sudo apt-get clean",
+        "sudo apt-get update"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
         "sudo apt-get -y install build-essential curl wget"
       ]
     },


### PR DESCRIPTION
As part of 5f3ed72 that added the _update_packages recipe to packer's
run_list, the APT update was removed to avoid redundancy. We install
build-essentials and wget to pull down and install Chef, which in turn
runs _update_packages.  Not doing an apt-get update prior to that ends
up looking for non-existent libc and other libraries, so adding back the
redundant update.

Signed-off-by: Raghu Raja <craghun@amazon.com>

---
@mohanasudhan like the commit message says, we have a chicken-and-egg problem and have to end up doing the update from both the shell provisioner as well as the cookbook. The packer files for the other OSes do not have this problem.
