### PR TITLE
Reboot after updating packages in packer.

### DIFF
--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -69,6 +69,14 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo apt-cache search build-essential",
+        "sudo apt-get clean",
+        "sudo apt-get update"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
         "sudo apt-get -y install build-essential curl wget"
       ]
     },

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -69,6 +69,14 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo apt-cache search build-essential",
+        "sudo apt-get clean",
+        "sudo apt-get update"
+      ]
+    },
+    {
+      "type" : "shell",
+      "inline" : [
         "sudo apt-get -y install build-essential curl wget"
       ]
     },


### PR DESCRIPTION
_update_pacakges would almost always bring in an updated kernel. Invoking the
cfncluster::default recipe without rebooting the instance right after causes
issues with recipes like the ones that install NVIDIA drivers, which pulls down
a version of kernel-devel newer than what the instance is running with at that
time.

The pause_before timeout is a bit conservative but gives plenty of time for
packer to reconnect to the instance after the reboot and before trying to run
the following provisioner.

Signed-off-by: Raghu Raja <craghun@amazon.com>