### PR TITLE
Reboot after updating packages in packer.

### DIFF
--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -103,6 +103,25 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::_update_packages"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {
@@ -116,7 +135,6 @@
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
-        "cfncluster::_update_packages",
         "cfncluster::default"
       ]
     },

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -103,6 +103,25 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::_update_packages"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {
@@ -116,7 +135,6 @@
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
-        "cfncluster::_update_packages",
         "cfncluster::default"
       ]
     },

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -103,6 +103,25 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::_update_packages"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {
@@ -116,7 +135,6 @@
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
-        "cfncluster::_update_packages",
         "cfncluster::default"
       ]
     },

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -111,6 +111,25 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::_update_packages"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {
@@ -124,7 +143,6 @@
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
-        "cfncluster::_update_packages",
         "cfncluster::default"
       ]
     },

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -111,6 +111,25 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::_update_packages"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo reboot"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {
@@ -124,7 +143,6 @@
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "run_list" : [
-        "cfncluster::_update_packages",
         "cfncluster::default"
       ]
     },


### PR DESCRIPTION
_update_pacakges would almost always bring in an updated kernel. Invoking the
cfncluster::default recipe without rebooting the instance right after causes
issues with recipes like the ones that install NVIDIA drivers, which pulls down
a version of kernel-devel newer than what the instance is running with at that
time.

The pause_before timeout is a bit conservative but gives plenty of time for
packer to reconnect to the instance after the reboot and before trying to run
the following provisioner.

Signed-off-by: Raghu Raja <craghun@amazon.com>