### PR TITLE
Use grub(v1) method of updating the conf for CentOS 6.

### DIFF
--- a/centos-upgrade-first-stage.sh
+++ b/centos-upgrade-first-stage.sh
@@ -80,8 +80,12 @@ sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/co
 # install) and turning off ifnames, because a bunch of the scripts expect
 # to find eth0.  Should handle the eth naming better, but that's todo.
 echo "Updating Grub command line"
-sudo /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
-sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+if test $is_centos6 -eq 1; then
+    sudo grubby --update-kernel=ALL --args="net.ifnames=0 rd.driver.blacklist=nouveau nouveau.modeset=0"
+else
+    sudo /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\1 net.ifnames=0 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
+    sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+fi
 
 echo "Update Complete.  Rebooting."
 # sleep for 30 seconds to make sure packer doesn't try to run the next


### PR DESCRIPTION
CentOS 7 uses Grub2, so the grub2-mkconfig approach works, but CentOS 6 still
uses Grub(1). Using grubby, which comes with the base AMI, to update the
arguments in CentOS 6.

Signed-off-by: Raghu Raja <craghun@amazon.com>