### PR TITLE
Update CentOS 6 base AMI.

### DIFF
--- a/centos-upgrade-second-stage.sh
+++ b/centos-upgrade-second-stage.sh
@@ -40,6 +40,11 @@ fi
 echo "Cleaning out old kernels"
 sudo package-cleanup -y --oldkernels --count=1
 
+if test $is_centos6 -eq 1; then
+    sudo yum install -y cloud-init cloud-utils dracut-modules-growroot cloud-utils-growpart
+    rpm -qa kernel-lt | sed 's/^kernel-lt-//'  | xargs -I {} sudo dracut -f /boot/initramfs-{}.img {}
+fi
+
 echo "Cleaning up filesystem"
 sudo rm -rf /tmp/* /var/tmp/* /var/log/* /etc/ssh/ssh_host*
 sudo rm -rf /root/* /root/.ssh /root/.history /root/.bash_history

--- a/packer_centos6.json
+++ b/packer_centos6.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-3b712841",
+      "source_ami" : "ami-44f1aa3e",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",
@@ -103,25 +103,6 @@
     },
     {
       "type" : "chef-solo",
-      "remote_cookbook_paths" : [
-        "/etc/chef/cookbooks"
-      ],
-      "skip_install" : "true",
-      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
-      "run_list" : [
-        "cfncluster::_update_packages"
-      ]
-    },
-    {
-      "type" : "shell",
-      "expect_disconnect" : "true",
-      "inline" : [
-        "sudo reboot"
-      ]
-    },
-    {
-      "type" : "chef-solo",
-      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {


### PR DESCRIPTION
Using the community CentOS AMI and updating to kernel-lt using the packer
pipeline we have is causing issues with the root volume resizing. Based on the
consensus the dev. team arrived at, this commit updates the base AMI by manually
deriving it from ami-9ff841e5 - the last-known AMI to have had kernel-lt working
well with growroot. The manual update included --- moving to the latest 4.x
kernel-lt, installing ENA driver, adding necessary grub commandline arguments to
grub.conf, and cleaning up temporary state and files.

Although not used for this AMI update, packer_update_centos_base.json has been
fixed to handle root volume resizing for future releases based on community AMIs.

Signed-off-by: Raghu Raja <craghun@amazon.com>