### PR TITLE
Updating CentOS 7 base AMI.

### DIFF
--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -17,7 +17,7 @@
     {
       "type" : "amazon-ebs",
       "region" : "us-east-1",
-      "source_ami" : "ami-8f752cf5",
+      "source_ami" : "ami-06fea57c",
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",


### PR DESCRIPTION
A rerun of packer_centos7 was required after the grub fixes to the packer
scripts to ensure the CentOS 7 path was unaffected.

Signed-off-by: Raghu Raja <craghun@amazon.com>