### PR TITLE
Revert "Region: Adding describe-regions api to pull regions list"

### DIFF
--- a/build_ami.sh
+++ b/build_ami.sh
@@ -8,7 +8,7 @@ public=$3
 build_date=$4
 
 available_os="centos6 centos7 alinux ubuntu1404 ubuntu1604"
-available_regions=$(aws ec2 describe-regions --output text | awk '{print $3}' | xargs | sed -e 's/ /,/g')
+available_regions="eu-west-1,eu-west-2,ap-southeast-1,ap-southeast-2,eu-central-1,ap-northeast-1,ap-northeast-2,us-west-2,sa-east-1,us-west-1,us-east-2,ap-south-1,ca-central-1"
 
 if [ "x$os" == "x" ]; then
   echo "Must provide OS to build."


### PR DESCRIPTION
Packer support for eu-west-3 is not released yet. Hence we can't
use packer command to copy image, so for now we have to manually copy image
to eu-west-3. Reverting this change to make packer happy with region validation.

Packer has to update it's code to use describe-region api
instead of maintaining it's own list of region. Will cut issue
to packer and possibly PR.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>
This reverts commit ce50d3432556e0cd56b6a36b639f294bde975774.