### PR TITLE
Fix SLURM's publish_pending cron job to push the correct metric

### DIFF
--- a/templates/default/publish_pending.slurm.erb
+++ b/templates/default/publish_pending.slurm.erb
@@ -22,7 +22,7 @@ if [ "$cfn_proxy" != "NONE" ]; then
   export no_proxy=169.254.169.254; export NO_PROXY=169.254.169.254
 fi
 
-pending=$(/opt/slurm/bin/squeue -r -h -o '%t %D' | awk '$1 == "PD" { total = total + 1} END {print total}')
+pending=$(/opt/slurm/bin/squeue -r -h -o '%t %D' | awk '$1 == "PD" { total = total + $2} END {print total}')
 
 if [ "${pending}x" == "x" ]; then
 pending=0


### PR DESCRIPTION
Until now, we seemed to have been publishing the number of pending jobs
to CloudWatch when running with SLURM. This inadvertently caused really
slow scale up.

Signed-off-by: Raghu Raja <craghun@amazon.com>