### PR TITLE
Fix Torque to use Node instead of Slots

### DIFF
--- a/templates/default/publish_pending.torque.erb
+++ b/templates/default/publish_pending.torque.erb
@@ -23,7 +23,7 @@ if [ "$cfn_proxy" != "NONE" ]; then
 fi
 
 . /etc/profile.d/torque.sh
-pending=$(qstat -i -t | tail -n+6 | awk '{total = total+ $7}END{print total}')
+pending=$(qstat -i -t | tail -n+6 | awk '{total = total+ $6}END{print total}')
 
 if [ "${pending}x" == "x" ]; then
 pending=0


### PR DESCRIPTION
## Overview
The command in torque is currently looking at the number of tasks (vcpus).
We recently updated slurm to look at number of nodes instead of jobs in queue. This
follows suit and updates torque.

Slurm fix: https://github.com/awslabs/cfncluster-cookbook/pull/99

Previously we totaled the task or `TSK` column which is vcpu's specified by the customer when they submit a job. For example `--nodes=1:ppn=4` results in 4 under `TSK` column and 1 under nodes `NDS` column. By looking at the `NDS` column we can make intelligent scaling decisions.

See `qstat` man page for info on displayed columns: https://linux.die.net/man/1/qstat-torque

## Testing

I submitted 3 jobs with `--nodes=2` and 3 with `--nodes=2:ppn=4`. This resulted in different totals for the `NDS` and `TSK` columns. I show the output below of the old command and the updated command:

```
[ec2-user@ip-172-31-52-55 ~]$ qstat -i -t

ip-172-31-52-55.ec2.internal:
                                                                                  Req'd       Req'd       Elap
Job ID                  Username    Queue    Jobname          SessID  NDS   TSK   Memory      Time    S   Time
----------------------- ----------- -------- ---------------- ------ ----- ------ --------- --------- - ---------
10.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      2       --   01:00:00 Q       --
11.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      2       --   01:00:00 Q       --
12.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      2       --   01:00:00 Q       --
13.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      8       --   01:00:00 Q       --
14.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      8       --   01:00:00 Q       --
15.ip-172-31-52-55.ec2  ec2-user    batch    run.sh              --      2      8       --   01:00:00 Q       --
[ec2-user@ip-172-31-52-55 ~]$ qstat -i -t | tail -n+6 | awk '{total = total + $6}END{print total}'
12
[ec2-user@ip-172-31-52-55 ~]$ qstat -i -t | tail -n+6 | awk '{total = total + $7}END{print total}'
30
```
