### PR TITLE
fix kitchen tests

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -16,6 +16,13 @@ driver_config:
 provisioner:
   name: chef_zero
   require_chef_omnibus: 12.19.36
+  retry_on_exit_code:
+    - 35 # 35 is the exit code signaling that the node is rebooting
+  max_retries: 1
+  wait_for_retry: 120
+  client_rb:
+    exit_status: :enabled # Opt-in to the standardized exit codes
+    client_fork: false  # Forked instances don't return the real exit code
 
 platforms:
   - name: amazon-linux-latest

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,8 +41,11 @@ default['cfncluster']['ganglia']['web_version'] = '3.7.2'
 default['cfncluster']['ganglia']['web_url'] = 'https://github.com/ganglia/ganglia-web/archive/3.7.2.tar.gz'
 # NVIDIA
 default['cfncluster']['nvidia']['enabled'] = 'no'
-default['cfncluster']['nvidia']['driver_url'] = 'http://us.download.nvidia.com/XFree86/Linux-x86_64/384.98/NVIDIA-Linux-x86_64-384.98.run'
+default['cfncluster']['nvidia']['driver_url'] = 'http://download.nvidia.com/XFree86/Linux-x86_64/390.48/NVIDIA-Linux-x86_64-390.48.run'
 default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run'
+
+# Update Packages Reboot
+default['cfncluster']['update_packages']['reboot'] = 'true'
 
 # OpenSSH settings for CfnCluster instances
 default['openssh']['server']['protocol'] = '2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ source_url 'https://github.com/awslabs/cfncluster-cookbook'
 version '1.4.1'
 
 depends 'build-essential', '~> 8.0.2'
-depends 'poise-python', '~> 1.6.0'
+depends 'poise-python', '~> 1.7.0'
 depends 'tar', '~> 2.0.0'
 depends 'selinux', '~> 2.0.0'
 depends 'nfs', '~> 2.4.1'

--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -108,6 +108,13 @@
       ],
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "update_packages" : {
+            "reboot" : "false"
+          }
+        }
+      },
       "run_list" : [
         "cfncluster::_update_packages"
       ]

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -108,6 +108,13 @@
       ],
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "update_packages" : {
+            "reboot" : "false"
+          }
+        }
+      },
       "run_list" : [
         "cfncluster::_update_packages"
       ]

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -116,6 +116,13 @@
       ],
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "update_packages" : {
+            "reboot" : "false"
+          }
+        }
+      },
       "run_list" : [
         "cfncluster::_update_packages"
       ]

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -116,6 +116,13 @@
       ],
       "skip_install" : "true",
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "update_packages" : {
+            "reboot" : "false"
+          }
+        }
+      },
       "run_list" : [
         "cfncluster::_update_packages"
       ]

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -43,7 +43,7 @@ if tagged?('rebooted')
   end
 end
 
-if (not tagged?('rebooted')) && node['cfncluster']['update_packages']['reboot'] == 'true'
+if !tagged?('rebooted') && node['cfncluster']['update_packages']['reboot'] == 'true'
   if node['platform'] == 'ubuntu'
     if node['platform_version'] == "16.04"
       file '/etc/tmpfiles.d/tmp.conf' do


### PR DESCRIPTION
- reboot after packages update:
  this solves the failing kitchen tests that weren't able to install the
  nvidia driver. The nvidia driver couldn't be installed because when
  doing a package update, there was a mismatch between the kernel library
  version and the version of the running kernel. Doing a reboot, it aligns
  those version, permitting to build and install the nvidia driver
  (with the dkms option)

- handle reboot on ubuntu:
  on ubuntu, the /tmp folder is erased by default.
  This patch prevent the folder to be erased during the reboot after
  packages upgrades. The configuration is then removed after the process
  restart after the reboot

- fix python depencency with poise-python:
  Poise-python 1.7.0 is up with full support for both Pip 10 and Chef 14.
  https://github.com/poise/poise-python/issues/107

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
