### PR TITLE
fix ruby syntax error "tried to create Proc object without a block"

### DIFF
--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -62,7 +62,7 @@ end
 # Add volume to /etc/fstab
 mount node['cfncluster']['cfn_shared_dir'] do
   device dev_path
-  fstype(DelayedEvaluator.new) { node['cfncluster']['cfn_volume_fs_type'] }
+  fstype(DelayedEvaluator.new { node['cfncluster']['cfn_volume_fs_type'] })
   options "_netdev"
   pass 0
   action %i[mount enable]


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
