### PR TITLE
add logic to deploy a custom cfncluster-node package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -153,3 +153,4 @@ default['cfncluster']['cfn_shared_dir'] = '/shared'
 default['cfncluster']['cfn_node_type'] = nil
 default['cfncluster']['cfn_master'] = nil
 default['cfncluster']['cfn_cluster_user'] = 'ec2-user'
+default['cfncluster']['custom_cfncluster_node'] = nil

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -97,9 +97,15 @@ remote_file '/usr/bin/ec2-metadata' do
   mode '0755'
 end
 
-# Install cfncluster-nodes packages
-python_package "cfncluster-node" do
-  version node['cfncluster']['cfncluster-node-version']
+if !node['cfncluster']['custom_cfncluster_node'].nil? && !node['cfncluster']['custom_cfncluster_node'].empty?
+  execute "install cfncluster-node" do
+    command "sudo pip uninstall --yes cfncluster-node && cd /tmp && curl -v -L -o /tmp/cfncluster-node.tgz #{node['cfncluster']['custom_cfncluster_node']} && tar -xzf /tmp/cfncluster-node.tgz && cd /tmp/cfncluster-node-* && sudo /usr/bin/python setup.py install"
+  end
+else
+  # Install cfncluster-nodes packages
+  python_package "cfncluster-node" do
+    version node['cfncluster']['cfncluster-node-version']
+  end
 end
 
 # Supervisord


### PR DESCRIPTION
cfncluster-node could be now uploaded to a personal bucket, then the link is provided to the chef run via additional json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
