### PR TITLE
avoid double execution of resources notified by or which subscribes other resources

### DIFF
--- a/recipes/_master_base_config.rb
+++ b/recipes/_master_base_config.rb
@@ -38,6 +38,7 @@ ruby_block "sleeping_for_volume" do
   block do
     wait_for_block_dev(dev_path)
   end
+  action :nothing
   subscribes :run, "execute[attach_volume]", :immediately
 end
 
@@ -47,6 +48,7 @@ ruby_block "setup_disk" do
     fs_type = setup_disk(dev_path)
     node.default['cfncluster']['cfn_volume_fs_type'] = fs_type
   end
+  action :nothing
   subscribes :run, "ruby_block[sleeping_for_volume]", :immediately
 end
 

--- a/recipes/torque_config.rb
+++ b/recipes/torque_config.rb
@@ -26,6 +26,7 @@ end
 # Run ldconfig
 execute "run-ldconfig" do
   command 'ldconfig'
+  action :nothing
 end
 
 # Set toruqe server_name


### PR DESCRIPTION
Chef executes resources in the order they appear in a recipe. But also
provide a way for:
- resource to be notified by other resources
- resource to subscribes other resources.

The default action for a resource is "run", so it is executed
sequentially as it appears in the recipe. If this resource subscribes
another resource, it is also executed when the subscribed resource change
its state.
Same speech for the resource notified by another resource.

With this change, the "not needed" double execution of a resource is avoided

Before patch
```
 * ruby_block[sleeping_for_volume] action run
           - execute the ruby block sleeping_for_volume
 * ruby_block[setup_disk] action run
           - execute the ruby block setup_disk
 * ruby_block[sleeping_for_volume] action run
           - execute the ruby block sleeping_for_volume
 * ruby_block[setup_disk] action run
          - execute the ruby block setup_disk
 * ruby_block[setup_disk] action run
           - execute the ruby block setup_disk
```

After patch
```
 * ruby_block[sleeping_for_volume] action run
           - execute the ruby block sleeping_for_volume
 * ruby_block[setup_disk] action run
           - execute the ruby block setup_disk
 * ruby_block[sleeping_for_volume] action nothing (skipped due to action :nothing)
 * ruby_block[setup_disk] action nothing (skipped due to action :nothing)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
