### PR TITLE
Add a loop to get block device attribute from EC2 instance

### DIFF
--- a/files/default/ec2_dev_2_volid.py
+++ b/files/default/ec2_dev_2_volid.py
@@ -4,24 +4,26 @@ import boto.ec2
 import urllib2
 import sys
 import os
+import syslog
+import time
 
 # Get dev
 try:
-  dev = str(sys.argv[1])
+    dev = str(sys.argv[1])
 except IndexError:
-  print "Provide block device i.e. xvdf"
-  sys.exit(1)
+    syslog.syslog(syslog.LOG_ERR, "Provide block device i.e. xvdf")
+    sys.exit(1)
 
 # Convert dev to mapping format
 if 'nvme' in dev:
-  # For newer instances which expose EBS volumes as NVMe devices, translate the
-  # device name so boto can discover it.
-  output = os.popen('sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme1').read().split(":")[1].strip()
-  print output
-  sys.exit(0)
+    # For newer instances which expose EBS volumes as NVMe devices, translate the
+    # device name so boto can discover it.
+    output = os.popen('sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme1').read().split(":")[1].strip()
+    print(output)
+    sys.exit(0)
 else:
-  dev = dev.replace('xvd', 'sd')
-  dev = '/dev/' + dev
+    dev = dev.replace('xvd', 'sd')
+    dev = '/dev/' + dev
 
 # Get instance ID
 instanceId = urllib2.urlopen("http://169.254.169.254/latest/meta-data/instance-id").read()
@@ -33,11 +35,18 @@ region = region[:-1]
 # Connect to AWS using boto
 conn = boto.ec2.connect_to_region(region)
 
-# Get blockdevicemapping
+# Poll for blockdevicemapping
 attrib = conn.get_instance_attribute(instanceId, 'blockDeviceMapping')
 devmap = attrib.get('blockDeviceMapping')
+x = 0
+while not devmap.has_key(dev):
+    if x == 36:
+        syslog.syslog("Dev %s did not appears in 180 seconds." % dev)
+        sys.exit(1)
+    syslog.syslog("Looking for dev %s into devmap %s" % (dev, devmap))
+    time.sleep(5)
+    attrib = conn.get_instance_attribute(instanceId, 'blockDeviceMapping')
+    devmap = attrib.get('blockDeviceMapping')
+    x += 1
 
-if devmap.has_key(dev):
-  print devmap[dev].volume_id
-else:
-  sys.exit(1)
+print(devmap[dev].volume_id)


### PR DESCRIPTION
It could happens that also if a volume appears to be attached to the
intance, the block device mapping attribute could get some time to be
updated.

A syslog has been added too

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
