### PR TITLE
Refactor recipes to fix Ubuntu interface renaming in kitchen steps

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,13 +13,13 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[cfncluster::_update_packages]
+      - recipe[cfncluster::_default_pre]
       - recipe[cfncluster::default]
     attributes:
 
   - name: default_gpu
     run_list:
-      - recipe[cfncluster::_update_packages]
+      - recipe[cfncluster::_default_pre]
       - recipe[cfncluster::default]
     attributes:
       cfncluster:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,8 +44,8 @@ default['cfncluster']['nvidia']['enabled'] = 'no'
 default['cfncluster']['nvidia']['driver_url'] = 'http://download.nvidia.com/XFree86/Linux-x86_64/390.48/NVIDIA-Linux-x86_64-390.48.run'
 default['cfncluster']['nvidia']['cuda_url'] = 'https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run'
 
-# Update Packages Reboot
-default['cfncluster']['update_packages']['reboot'] = 'true'
+# Reboot after default_pre recipe
+default['cfncluster']['default_pre_reboot'] = 'true'
 
 # OpenSSH settings for CfnCluster instances
 default['openssh']['server']['protocol'] = '2'

--- a/packer_alinux.json
+++ b/packer_alinux.json
@@ -110,13 +110,11 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
-          "update_packages" : {
-            "reboot" : "false"
-          }
+          "default_pre_reboot" : "false"
         }
       },
       "run_list" : [
-        "cfncluster::_update_packages"
+        "cfncluster::_default_pre"
       ]
     },
     {

--- a/packer_centos7.json
+++ b/packer_centos7.json
@@ -110,13 +110,11 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
-          "update_packages" : {
-            "reboot" : "false"
-          }
+          "default_pre_reboot" : "false"
         }
       },
       "run_list" : [
-        "cfncluster::_update_packages"
+        "cfncluster::_default_pre"
       ]
     },
     {

--- a/packer_ubuntu1404.json
+++ b/packer_ubuntu1404.json
@@ -118,13 +118,11 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
-          "update_packages" : {
-            "reboot" : "false"
-          }
+          "default_pre_reboot" : "false"
         }
       },
       "run_list" : [
-        "cfncluster::_update_packages"
+        "cfncluster::_default_pre"
       ]
     },
     {

--- a/packer_ubuntu1604.json
+++ b/packer_ubuntu1604.json
@@ -118,13 +118,11 @@
       "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
       "json" : {
         "cfncluster" : {
-          "update_packages" : {
-            "reboot" : "false"
-          }
+          "default_pre_reboot" : "false"
         }
       },
       "run_list" : [
-        "cfncluster::_update_packages"
+        "cfncluster::_default_pre"
       ]
     },
     {
@@ -171,13 +169,6 @@
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
-      ]
-    },
-    {
-      "type" : "shell",
-      "inline" : [
-        "sudo /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"net.ifnames=0 biosdevname=0\"/' /etc/default/grub",
-        "sudo grub-mkconfig -o /boot/grub/grub.cfg"
       ]
     }
   ]

--- a/recipes/_default_pre.rb
+++ b/recipes/_default_pre.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook Name:: cfncluster
+# Recipe:: _default_pre
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe 'cfncluster::_setup_network'
+include_recipe 'cfncluster::_update_packages'
+
+
+# Reboot after preliminary configuration steps
+if !tagged?('rebooted') && node['cfncluster']['default_pre_reboot'] == 'true'
+  # On Ubuntu, the /tmp folder is erased by default after a reboot and its lifecycle is managed
+  # by different tools, depending on the Ubuntu version
+  if node['platform'] == 'ubuntu'
+    if node['platform_version'] == "16.04"
+      file '/etc/tmpfiles.d/tmp.conf' do
+        content 'd /tmp 1777 root root 1d'
+      end
+    end
+    if node['platform_version'] == "14.04"
+      execute 'sed' do
+        command "sed -i s/#TMPTIME=0/TMPTIME=1/g /etc/default/rcS"
+      end
+    end
+  end
+
+  tag('rebooted')
+  reboot 'now' do
+    action :reboot_now
+    delay_mins 1
+    reason 'Cannot continue Chef run without a reboot after packages update.'
+  end
+end
+
+# Remove the configuration to keep the /tmp folder on Ubuntu after a reboot
+if tagged?('rebooted')
+  if node['platform'] == 'ubuntu'
+    if node['platform_version'] == "16.04"
+      file '/etc/tmpfiles.d/tmp.conf' do
+        action :delete
+        only_if { File.exist? '/etc/tmpfiles.d/tmp.conf' }
+      end
+    end
+    if node['platform_version'] == "14.04"
+      execute 'sed' do
+        command "sed -i s/TMPTIME=1/#TMPTIME=0/g /etc/default/rcS"
+      end
+    end
+  end
+end

--- a/recipes/_setup_network.rb
+++ b/recipes/_setup_network.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: cfncluster
-# Recipe:: _update_packages
+# Recipe:: _setup_network
 #
-# Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
 # License. A copy of the License is located at
@@ -13,16 +13,13 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-case node['platform_family']
-when 'rhel'
-  execute 'yum-update' do
-    command "yum -y update && package-cleanup -y --oldkernels --count=1"
-  end
-when 'debian'
-  execute 'apt-update' do
-    command "apt-get update"
-  end
-  execute 'apt-upgrade' do
-    command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade && apt-get autoremove"
+if node['platform'] == 'ubuntu'
+  if node['platform_version'] == "16.04"
+    execute 'sed' do
+      command "/bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX=\"(.*)\"/GRUB_CMDLINE_LINUX=\"net.ifnames=0 biosdevname=0\"/' /etc/default/grub"
+    end
+    execute 'grub_mkconfig' do
+      command "grub-mkconfig -o /boot/grub/grub.cfg"
+    end
   end
 end


### PR DESCRIPTION
The https://github.com/awslabs/cfncluster-cookbook/pull/70 added shell commands to avoid the systemd v197 interface naming
and use the ethX syntax, for the Ubuntu 16 packer template.
With this patch we are fixing the kitchen part too.

The new _default_pre recipe is shared from packer and kitchen and
includes both the _update_packages and the new _setup_network recipes.
This step will be execute before the reboot steps.

Tests:
* packer creation
* kitchen test

Ref:
https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/

Signed-off-by: Enrico Usai <usai@amazon.com>
