### PR TITLE
rename variable to customize cfncluster node package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -153,4 +153,4 @@ default['cfncluster']['cfn_shared_dir'] = '/shared'
 default['cfncluster']['cfn_node_type'] = nil
 default['cfncluster']['cfn_master'] = nil
 default['cfncluster']['cfn_cluster_user'] = 'ec2-user'
-default['cfncluster']['custom_cfncluster_node'] = nil
+default['cfncluster']['custom_node_package'] = nil

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -97,9 +97,14 @@ remote_file '/usr/bin/ec2-metadata' do
   mode '0755'
 end
 
-if !node['cfncluster']['custom_cfncluster_node'].nil? && !node['cfncluster']['custom_cfncluster_node'].empty?
+if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custom_node_package'].empty?
   execute "install cfncluster-node" do
-    command "sudo pip uninstall --yes cfncluster-node && cd /tmp && curl -v -L -o /tmp/cfncluster-node.tgz #{node['cfncluster']['custom_cfncluster_node']} && tar -xzf /tmp/cfncluster-node.tgz && cd /tmp/cfncluster-node-* && sudo /usr/bin/python setup.py install"
+    command "sudo pip uninstall --yes cfncluster-node &&" \
+      "cd /tmp &&" \
+      "curl -v -L -o /tmp/cfncluster-node.tgz #{node['cfncluster']['custom_node_package']} &&" \
+      "tar -xzf /tmp/cfncluster-node.tgz &&" \
+      "cd /tmp/cfncluster-node-* &&" \
+      "sudo /usr/bin/python setup.py install"
   end
 else
   # Install cfncluster-nodes packages


### PR DESCRIPTION
to deploy a custom cfncluster-node package upload an archive containing
the node package into a S3 public readable bucket.
Add an extra json to the cfncluster config file, with the variable
"custom_node_package" containing the link to the bucket object
e.g.
extra_json = { "cfncluster" : { "custom_node_package" : "<bucket-with-node-package-archive>" } }

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
