### PR TITLE
dynamically create region list in place of use a static list

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -25,7 +25,7 @@ public=$3
 build_date=$4
 
 available_os="centos6 centos7 alinux ubuntu1404 ubuntu1604"
-available_regions="eu-west-1,eu-west-2,eu-west-3,ap-southeast-1,ap-southeast-2,eu-central-1,ap-northeast-1,ap-northeast-2,ap-northeast-3,us-west-2,sa-east-1,us-west-1,us-east-2,ap-south-1,ca-central-1"
+available_regions="$(aws ec2 --region us-east-1 describe-regions --query Regions[].RegionName --output text | tr '\t' ',' | sort -n)"
 cwd="$(dirname $0)"
 export VENDOR_PATH="${cwd}/../../vendor/cookbooks"
 


### PR DESCRIPTION
Current output is:

```
$ aws ec2 --region eu-west-1 describe-regions --query Regions[].RegionName --output text | tr '\t' ',' | sort -n

ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-3,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2
```
so we have the same regions of the static list.