### PR TITLE
Add the possibility to specify a region different from us-east-1

### DIFF
--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -45,8 +45,11 @@ if [ "${public}" == "public" ]; then
   export AMI_PERMS="all"
 fi
 
+# NOTE: the AMI is always built in us-east-1 and then copied to the specified regions
 if [ "${region}" == "all" ]; then
   export BUILD_FOR=${available_regions}
+else
+  export BUILD_FOR=${region}
 fi
 
 RC=0


### PR DESCRIPTION
The BUILD_FOR variable will be used by packer.
NOTE: the AMI is always built in us-east-1 and then copied to the specified region