### PR TITLE
Install or update AWS CLI into AMIs for all distro

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -59,7 +59,10 @@ cookbook_file 'CfnCluster-License-README.txt' do
 end
 
 # Install AWSCLI
-python_package 'awscli'
+python_package 'awscli' do
+  action :upgrade
+  version '1.15.40'
+end
 
 # TODO: update nfs receipes to stop, disable nfs services
 include_recipe "nfs"


### PR DESCRIPTION
When building AMIs Ubuntu 14 and 16 Linux distributions get installed
with the latest version of the AWS CLI. Amazon, CentOS 6, 7 AMIs
are built from pre-cooked AMIs with already installed a different and
older version of the AWS-CLI.
This change installs and updates the AWS CLI to tested version 1.15.40,
for all distros when building the AMIs for CfnCluster.
It also executes the AWS-CLI update during the provisioning of the
master and compute nodes.

Signed-off-by: Maurizio Melato <mmelato@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
