### PR TITLE
Relax FoodCritic check on the release version nr

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,11 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:chefspec)
 
 # foodcritic rake task
+# Rule FC061 was removed to avoid strict release number format x.y.z
+# and to allow alpha/beta/rc versions
 desc 'Foodcritic linter'
 task :foodcritic do
-  sh 'foodcritic -f correctness .'
+  sh 'foodcritic -f correctness . --tags ~FC061'
 end
 
 # rubocop rake task


### PR DESCRIPTION
This change removes strict version format checking (x.y.z)  allowing us
to have cookbook package versions for alpha/beta/rc.

Signed-off-by: Maurizio Melato <mmelato@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
