### PR TITLE
Fix 1.5.1 Cookbook Version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,9 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:chefspec)
 
 # foodcritic rake task
-# Rule FC061 was removed to avoid strict release number format x.y.z
-# and to allow alpha/beta/rc versions
 desc 'Foodcritic linter'
 task :foodcritic do
-  sh 'foodcritic -f correctness . --tags ~FC061'
+  sh 'foodcritic -f correctness .'
 end
 
 # rubocop rake task

--- a/amis/packer_variables.json
+++ b/amis/packer_variables.json
@@ -1,6 +1,6 @@
 {
   "cfncluster_version": "1.5.1rc1",
-  "cfncluster_cookbook_version": "1.5.1rc1",
+  "cfncluster_cookbook_version": "1.5.1",
   "chef_version": "12.19.36",
   "ridley_version": "5.1.0",
   "berkshelf_version": "5.6.4"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures cfncluster'
 long_description 'Installs/Configures cfncluster'
 issues_url 'https://github.com/awslabs/cfncluster-cookbook/issues'
 source_url 'https://github.com/awslabs/cfncluster-cookbook'
-version '1.5.1rc1'
+version '1.5.1'
 
 depends 'build-essential', '~> 8.0.2'
 depends 'poise-python', '~> 1.7.0'


### PR DESCRIPTION
Chef does not accept versions that are not in the form x.y.z
Changing version to 1.5.1

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
