### PR TITLE
Fix kitchen tests to use the same AMI ids used in the packer templates

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -89,7 +89,7 @@ platforms:
   - name: centos-6-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-9ff841e5
+      image_id: ami-44f1aa3e
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:
@@ -150,7 +150,7 @@ platforms:
   - name: centos-7-minimal
     driver_plugin: ec2
     driver_config:
-      image_id: ami-01098c7b
+      image_id: ami-06fea57c
       block_device_mappings:
         - device_name: /dev/sda1
           ebs:


### PR DESCRIPTION
CentOS6 and CentOS7 kitchen tests were using old AMIs.
We are aligning them to the ones used by packer to test the actually distributed AMIs.

Tested by executing _default-centos-6-minimal_ and _default-centos-7-minimal_ kitchen tests.