### PR TITLE
Add prefix on ami name generated by packer

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -12,7 +12,8 @@
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
-    "vpc_id" : "{{env `AWS_VPC_ID`}}"
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
   },
   "builders" : [
     {
@@ -24,7 +25,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ec2-user",
       "ssh_pty" : true,
-      "ami_name" : "cfncluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -12,7 +12,8 @@
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
-    "vpc_id" : "{{env `AWS_VPC_ID`}}"
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
   },
   "builders" : [
     {
@@ -24,7 +25,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "cfncluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -12,7 +12,8 @@
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
-    "vpc_id" : "{{env `AWS_VPC_ID`}}"
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
   },
   "builders" : [
     {
@@ -24,7 +25,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "cfncluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -12,7 +12,8 @@
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
-    "vpc_id" : "{{env `AWS_VPC_ID`}}"
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
   },
   "builders" : [
     {
@@ -24,7 +25,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "cfncluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -12,7 +12,8 @@
     "nvidia_enabled" : "{{env `NVIDIA_ENABLED`}}",
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
-    "vpc_id" : "{{env `AWS_VPC_ID`}}"
+    "vpc_id" : "{{env `AWS_VPC_ID`}}",
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
   },
   "builders" : [
     {
@@ -24,7 +25,7 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "cfncluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,


### PR DESCRIPTION
It is now possible to add a prefix to the ami name exporting the
environment variable AMI_NAME_PREFIX

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
