### PR TITLE
Make m5d/c5d instances work

### DIFF
--- a/files/default/ec2_dev_2_volid.py
+++ b/files/default/ec2_dev_2_volid.py
@@ -18,7 +18,7 @@ except IndexError:
 if 'nvme' in dev:
     # For newer instances which expose EBS volumes as NVMe devices, translate the
     # device name so boto can discover it.
-    output = os.popen('sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme1').read().split(":")[1].strip()
+    output = os.popen('sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/' + dev).read().split(":")[1].strip()
     print(output)
     sys.exit(0)
 else:


### PR DESCRIPTION
We have to use the input device name and not a fixed `nvme1` string.

This solves: https://github.com/awslabs/cfncluster/issues/415

E.g. in m5d instances the `nvme1 `is not an EBS device:
```
# ls /dev/nvme*
/dev/nvme0  /dev/nvme0n1  /dev/nvme0n1p1  /dev/nvme0n1p128  /dev/nvme1  /dev/nvme1n1  /dev/nvme1n1p1  /dev/nvme2  /dev/nvme2n1
# sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme1
[ERROR] Not an EBS device: '/dev/nvme1'

# sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme0
Volume ID: vol-042f0779f7e1b0090
# sudo /usr/local/sbin/cfncluster-ebsnvme-id -v /dev/nvme2
Volume ID: vol-02fd4031aef3eeee3
```

I tested kitchen tests for both _c5d.xlarge_ and _m5d.xlarge_ instances.



