### PR TITLE
fix build on centos6 (packer and kitchen)

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -62,3 +62,7 @@ def get_vpc_ipv4_cidr_block(eth0_mac)
 
   vpc_ipv4_cidr_block
 end
+
+def pip_install_package(package, version)
+  Mixlib::ShellOut.new("pip install #{package}==#{version}").run_command
+end

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -110,9 +110,18 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
       "sudo /usr/bin/python setup.py install"
   end
 else
-  # Install cfncluster-nodes packages
-  python_package "cfncluster-node" do
-    version node['cfncluster']['cfncluster-node-version']
+  # Install cfncluster-node package
+  if node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7
+    # For CentOS 6 use shell_out function in order to have a correct PATH needed to compile cfncluster-node dependencies
+    ruby_block "pip_install_cfncluster_node" do
+      block do
+        pip_install_package('cfncluster-node', node['cfncluster']['cfncluster-node-version'])
+      end
+    end
+  else
+    python_package "cfncluster-node" do
+      version node['cfncluster']['cfncluster-node-version']
+    end
   end
 end
 


### PR DESCRIPTION
Regression was introduced with the chef update from version 12 to 14.
As described here
https://github.com/chef/chef/commit/d24976bbd8846a60d186790f38124f312e91473d
and here
https://github.com/chef/chef/commit/b2b87c35ceb2d6e05c2be2f381b3e3dbe86a3dd1
the default path_sanity configuration was changed from true to false.
This is causing an issue on CentOS 6 where the PATH variable doesn't
contains the correct locations of the devel packages needed during the
installation of the cfncluster-node dependencies.
In particular, "pip install cffi" was not able to find the ffi.h header
file which is installed a step before via "yum install libffi-devel".

Using the shell_out function, we are forcing the variable PATH to contains
all the needed locations.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
