### PR TITLE
Fix Attachment State IndexError

### DIFF
--- a/files/default/attachVolume.py
+++ b/files/default/attachVolume.py
@@ -34,10 +34,11 @@ ec2 = boto3.client('ec2', region_name=region)
 
 # Attach the volume
 dev = availableDevices[0].replace('xvd', 'sd')
-ec2.attach_volume(VolumeId=volumeId, InstanceId=instanceId, Device=dev)
+response = ec2.attach_volume(VolumeId=volumeId, InstanceId=instanceId, Device=dev)
 
 # Poll for volume to attach
-state = ec2.describe_volumes(VolumeIds=[volumeId]).get('Volumes')[0].get('Attachments')[0].get('State')
+state = response.get("State")
+
 x = 0
 while state != "attached":
     if x == 36:


### PR DESCRIPTION
This addresses a transient error where the attachments were
not available immediately from the `describe_volumes()` call.
This uses the return status from `attach_volume()` to get the
state, saving a call to `describe_volumes()` until 5 seconds has passed.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
