### PR TITLE
Add Proxy to sqswatcher and nodewatcher

### DIFF
--- a/templates/default/nodewatcher.cfg.erb
+++ b/templates/default/nodewatcher.cfg.erb
@@ -1,3 +1,4 @@
 [nodewatcher]
 region = <%= node['cfncluster']['cfn_region'] %>
 scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
+proxy = <%= node['cfncluster']['cfn_proxy'] %>

--- a/templates/default/sqswatcher.cfg.erb
+++ b/templates/default/sqswatcher.cfg.erb
@@ -4,3 +4,4 @@ sqsqueue = <%= node['cfncluster']['cfn_sqs_queue'] %>
 table_name = <%= node['cfncluster']['cfn_ddb_table'] %>
 scheduler = <%= node['cfncluster']['cfn_scheduler'] %>
 cluster_user = <%= node['cfncluster']['cfn_cluster_user'] %>
+proxy = <%= node['cfncluster']['cfn_proxy'] %>


### PR DESCRIPTION
Boto3 uses a different format for proxies. Instead of
using the boto2 config, /etc/boto.cfg, the proxy
settings need to be in nodewatcher.cfg and sqswatcher.cfg.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.