### PR TITLE
Adding slots information to slurm

### DIFF
--- a/templates/default/slurm.conf.erb
+++ b/templates/default/slurm.conf.erb
@@ -62,7 +62,8 @@ SchedulerType=sched/backfill
 #SchedulerAuth=
 #SchedulerPort=
 #SchedulerRootFilter=
-SelectType=select/linear
+SelectType=select/cons_res
+SelectTypeParameters=CR_CPU
 
 # Disable fastscheduling to fall back on resource
 # metrics reported by compute nodes, slower scheduling


### PR DESCRIPTION
On host addition, the slurm configuration is changed to add the number
of slots for the compute node. This information is coming from the sqs
message sent by the compute node itself.

In order to allow to submit more than one job per node, the scheduler
needs also to be configured to use CPUs as consumable resource. This is
done setting the params SelectType and SelectTypeParameters as described
into https://slurm.schedmd.com/slurm.conf.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Test Result using m4.10xlarge (40 CPUs) for Compute nodes.
Without patch, only one job per node. Submitting 5 jobs, only 2 of them go running:
```
$ for i in {1..5}; do sbatch —wrap="sleep 10; echo $(date) $(hostname)"; done
Submitted batch job 2
Submitted batch job 3
Submitted batch job 4
Submitted batch job 5
Submitted batch job 6
$ squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
                1.  compute     wrap ec2-user PD       0:00      1 (Resources)
                2.  compute     wrap ec2-user PD       0:00      1 (Priority)
                3.  compute     wrap ec2-user PD       0:00      1 (Priority)
                4.  compute     wrap ec2-user  R       0:02      1 ip-172-31-2-91
                5.  compute     wrap ec2-user  R       0:02      1 ip-172-31-10-45
```

With this patch, multiple job per node. Submitting 5 jobs, all of them go running:
```
$ for i in {1..5}; do sbatch —wrap="sleep 10; echo $(date) $(hostname)"; done
Submitted batch job 382
Submitted batch job 383
Submitted batch job 384
Submitted batch job 385
Submitted batch job 386
[ec2-user@ip-172-31-6-97 ~]$ squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)

            1.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            2.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            3.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            4.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            5.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
```

With this patch, multiple job per node. Submitting 10 jobs on a cluster with 5 nodes, and requesting 20 "slots" per node. All of them go running, distributed on all 5 nodes:

```
$ for i in {1..10}; do sbatch —ntasks-per-node=20 —wrap="sleep 10; echo $(date) $(hostname)"; done
Submitted batch job 372
Submitted batch job 373
Submitted batch job 374
Submitted batch job 375
Submitted batch job 376
Submitted batch job 377
Submitted batch job 378
Submitted batch job 379
Submitted batch job 380
Submitted batch job 381
[ec2-user@ip-172-31-6-97 ~]$ squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)

            1.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            2.  compute     wrap ec2-user  R       0:01      1 ip-172-31-3-125
            3.  compute     wrap ec2-user  R       0:01      1 ip-172-31-5-34
            4.  compute     wrap ec2-user  R       0:01      1 ip-172-31-5-34
            5.  compute     wrap ec2-user  R       0:01      1 ip-172-31-8-8
            6.  compute     wrap ec2-user  R       0:01      1 ip-172-31-8-8
            7.  compute     wrap ec2-user  R       0:01      1 ip-172-31-8-52
            8.  compute     wrap ec2-user  R       0:01      1 ip-172-31-8-52
            9.  compute     wrap ec2-user  R       0:01      1 ip-172-31-14-69
            10.  compute     wrap ec2-user  R       0:01      1 ip-172-31-14-69
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
