### PR TITLE
Use Source AMI Filter to get latest base AMI

### DIFF
--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -13,13 +13,22 @@
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
-    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}"
   },
   "builders" : [
     {
       "type" : "amazon-ebs",
-      "region" : "us-east-1",
-      "source_ami" : "ami-55ef662f",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "amzn-ami-hvm-*.*.*.*-x86_64-gp2",
+          "root-device-type": "ebs",
+          "owner-alias": "amazon"
+        },
+        "most_recent": true
+      },
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -13,13 +13,22 @@
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
-    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}"
   },
   "builders" : [
     {
       "type" : "amazon-ebs",
-      "region" : "us-east-1",
-      "source_ami" : "ami-44f1aa3e",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "CentOS 6.x x86_64 - minimal with cloud-init - *",
+          "root-device-type": "ebs"
+        },
+        "owners": ["247102896272"],
+        "most_recent": true
+      },
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -13,13 +13,22 @@
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
-    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}"
   },
   "builders" : [
     {
       "type" : "amazon-ebs",
-      "region" : "us-east-1",
-      "source_ami" : "ami-06fea57c",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "CentOS 7.x x86_64 - minimal with cloud-init - *",
+          "root-device-type": "ebs"
+        },
+        "owners": ["247102896272"],
+        "most_recent": true
+      },
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
       "instance_type" : "{{user `instance_type`}}",

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -13,15 +13,24 @@
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
-    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}"
   },
   "builders" : [
     {
       "type" : "amazon-ebs",
-      "region" : "us-east-1",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*",
+          "root-device-type": "ebs"
+        },
+        "owners": ["099720109477", "513442679011"],
+        "most_recent": true
+      },
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-c29e1cb8",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -13,15 +13,24 @@
     "instance_type" : "{{env `AWS_FLAVOR_ID`}}",
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
-    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}"
+    "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
+    "region" : "{{env `AWS_REGION`}}"
   },
   "builders" : [
     {
       "type" : "amazon-ebs",
-      "region" : "us-east-1",
+      "region" : "{{user `region`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "name": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*",
+          "root-device-type": "ebs"
+        },
+        "owners": ["099720109477", "513442679011"],
+        "most_recent": true
+      },
       "ami_regions" : "{{user `build_for`}}",
       "ami_groups" : "{{user `ami_perms`}}",
-      "source_ami" : "ami-aa2ea6d0",
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,


### PR DESCRIPTION
Uses `source_ami_filter` to find latest ami in region.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
