### PR TITLE
Set accounting_summary to TRUE for multi node job journaling

### DIFF
--- a/recipes/_master_sge_config.rb
+++ b/recipes/_master_sge_config.rb
@@ -55,6 +55,17 @@ bash "add_host_as_master" do
   ADDHOST
 end
 
+bash "set_accounting_summary" do
+  code <<-SETAS
+    . /opt/sge/default/common/settings.sh
+    TMPFILE=/tmp/pe.txt
+    qconf -sp mpi | grep -v 'accounting_summary' > $TMPFILE
+    echo 'accounting_summary TRUE' >> $TMPFILE
+    qconf -Mp $TMPFILE
+    rm $TMPFILE
+  SETAS
+end
+
 template '/opt/cfncluster/scripts/publish_pending' do
   source 'publish_pending.sge.erb'
   owner 'root'


### PR DESCRIPTION
For jobs that run on multiple nodes, each node will have an exit_status and each node will write its output to the journaling file on the master node. This makes it so that only the combined process writes an entry to the journaling file (if even one node fails, the job fails and returns the failed exit code).

Signed-off-by: Elveskevtar <kevtar@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.