### PR TITLE
Fix packer build for ubuntu1404

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -61,7 +61,9 @@ end
 # Install AWSCLI
 python_package 'awscli' do
   action :upgrade
-  version '1.15.40'
+  if node['platform'] == 'ubuntu' && node['platform_version'] == "14.04"
+    install_options '--ignore-installed urllib3'
+  end
 end
 
 # Install boto3


### PR DESCRIPTION
This fix the following errors on ubuntu1404:
- awscli 1.15.40 has requirement botocore==1.10.40%!(PACKER_COMMA)
but you'll have botocore 1.11.1 which is incompatible.
- Cannot uninstall 'urllib3'. It is a distutils installed project and
thus we cannot accurately determine which files belong to it which
would lead to only a partial uninstall.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
