### PR TITLE
Perform floating point division and get ceil of the result

### DIFF
--- a/recipes/_prep_env.rb
+++ b/recipes/_prep_env.rb
@@ -17,7 +17,7 @@
 node.default['cfncluster']['cfn_instance_slots'] = if node['cfncluster']['cfn_scheduler_slots'] == 'vcpus'
                                                      node['cpu']['total']
                                                    elsif node['cfncluster']['cfn_scheduler_slots'] == 'cores'
-                                                     node['cpu']['total'] / 2
+                                                     node['cpu']['total'].fdiv(2).ceil
                                                    else
                                                      node['cfncluster']['cfn_scheduler_slots']
                                                    end


### PR DESCRIPTION
Perform floating point division and get ceil of the result instead of integer division

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
