### PR TITLE
Update chef supermarket website

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata


### PR DESCRIPTION
The old _supermarket.getchef.com_ has been moved permanently to _supermarket.chef.io_
