### PR TITLE
Unpin awscli package version

### DIFF
--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -115,6 +115,32 @@
     },
     {
       "type" : "chef-solo",
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "json" : {
+        "cfncluster" : {
+          "default_pre_reboot" : "false"
+        }
+      },
+      "run_list" : [
+        "cfncluster::_default_pre"
+      ]
+    },
+    {
+      "type" : "shell",
+      "expect_disconnect" : "true",
+      "inline" : [
+        "sudo /etc/init.d/sshd stop",
+        "nohup sudo shutdown -r now < /dev/null > /dev/null 2>&1 &",
+        "exit 0"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "pause_before": "2m",
       "json" : {
         "cfncluster" : {
           "nvidia" : {

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -13,16 +13,36 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-case node['platform_family']
-when 'rhel', 'amazon'
-  execute 'yum-update' do
-    command "yum -y update && package-cleanup -y --oldkernels --count=1"
-  end
-when 'debian'
-  execute 'apt-update' do
-    command "apt-get update"
-  end
-  execute 'apt-upgrade' do
-    command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade && apt-get autoremove"
+if node['platform'] == 'centos' && node['platform_version'].to_i >= 7
+  # CentOS7
+  bash 'remove awscli' do
+    code <<-AWSCLI
+      yum -y remove awscli
+    AWSCLI
   end
 end
+
+if not (node['platform'] == 'centos' && node['platform_version'].to_i < 7)
+  # not CentOS6
+  case node['platform_family']
+  when 'rhel', 'amazon'
+    execute 'yum-update' do
+      command "yum -y update && package-cleanup -y --oldkernels --count=1"
+    end
+  when 'debian'
+    execute 'apt-update' do
+      command "apt-get update"
+    end
+    execute 'apt-upgrade' do
+      command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade && apt-get autoremove"
+    end
+  end
+else
+  # CentOS6
+  bash 'remove awscli' do
+    code <<-AWSCLI
+      pip uninstall -y awscli
+    AWSCLI
+  end
+end
+

--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -60,8 +60,6 @@ end
 
 # Install AWSCLI
 python_package 'awscli' do
-  action :upgrade
-  version '1.16.2'
   if node['platform'] == 'ubuntu' && node['platform_version'] == "14.04"
     install_options '--ignore-installed urllib3'
   end


### PR DESCRIPTION
Install latest version of awscli at packer time, or do nothing if
already installed, so to avoid to break package dependencies.

For CentOS6 and CentOS7, we need also to cleanup any old awscli package
installed via staging scripts, in order to avoid package dependencies
break when installing latest boto3 package.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
