### PR TITLE
Add very basic test to see if aws cli is working

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -73,6 +73,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::sge_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'MasterServer'
@@ -90,6 +91,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::torque_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'MasterServer'
@@ -107,6 +109,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::slurm_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'MasterServer'
@@ -124,6 +127,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::sge_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'ComputeFleet'
@@ -141,6 +145,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::torque_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'ComputeFleet'
@@ -158,6 +163,7 @@ suites:
     run_list:
       - recipe[cfncluster::_prep_env]
       - recipe[cfncluster::slurm_config]
+      - recipe[cfncluster::tests]
     attributes:
       cfncluster:
         cfn_node_type: 'ComputeFleet'

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -1,0 +1,19 @@
+#
+# Cookbook Name:: cfncluster
+# Recipe:: tests
+#
+# Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+bash 'execute awscli' do
+  code "aws --version"
+end


### PR DESCRIPTION
The test is done after awscli and boto3 packages are installed during
the runtime recipes. This should highlight any possible problem due
tue broken dependencies (e.g latest boto3 version installed over an
old version of awscli)

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
