### PR TITLE
Cleanup awscli package installed by default

### DIFF
--- a/recipes/_default_pre.rb
+++ b/recipes/_default_pre.rb
@@ -15,7 +15,6 @@
 
 include_recipe 'cfncluster::_update_packages'
 
-
 # Reboot after preliminary configuration steps
 if !tagged?('rebooted') && node['cfncluster']['default_pre_reboot'] == 'true'
   # On Ubuntu, the /tmp folder is erased by default after a reboot and its lifecycle is managed

--- a/recipes/_update_packages.rb
+++ b/recipes/_update_packages.rb
@@ -13,16 +13,24 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-if node['platform'] == 'centos' && node['platform_version'].to_i >= 7
-  # CentOS7
+package 'aws-cli' do
+  action :remove
+  ignore_failure true
+end
+
+if !(node['platform'] == 'ubuntu' && node['platform_version'] == "16.04")
+  python_package 'awscli' do
+    action :remove
+    ignore_failure true
+  end
+else
   bash 'remove awscli' do
-    code <<-AWSCLI
-      yum -y remove awscli
-    AWSCLI
+    code "pip uninstall -y awscli"
+    ignore_failure true
   end
 end
 
-if not (node['platform'] == 'centos' && node['platform_version'].to_i < 7)
+unless node['platform'] == 'centos' && node['platform_version'].to_i < 7
   # not CentOS6
   case node['platform_family']
   when 'rhel', 'amazon'
@@ -37,12 +45,4 @@ if not (node['platform'] == 'centos' && node['platform_version'].to_i < 7)
       command "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade && apt-get autoremove"
     end
   end
-else
-  # CentOS6
-  bash 'remove awscli' do
-    code <<-AWSCLI
-      pip uninstall -y awscli
-    AWSCLI
-  end
 end
-

--- a/recipes/tests.rb
+++ b/recipes/tests.rb
@@ -13,7 +13,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-bash 'execute awscli' do
-  code "aws --version"
+execute 'execute awscli' do
+  command "aws --version"
+  environment('PATH' => '/usr/local/bin:$PATH')
+  user node['cfncluster']['cfn_cluster_user']
 end


### PR DESCRIPTION
The installation of awscli is done later via pip, in order to avoid
any possible dependency problem with the boto3 package installed
subsequently

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
