### PR TITLE
Fix random packer failures when provisioning Ubuntu

### DIFF
--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -79,6 +79,12 @@
   ],
   "provisioners" : [
     {
+      "type": "shell",
+      "inline": [
+        "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done"
+      ]
+    },
+    {
       "type" : "shell",
       "inline" : [
         "sudo apt-cache search build-essential",

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -79,6 +79,12 @@
   ],
   "provisioners" : [
     {
+      "type": "shell",
+      "inline": [
+        "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done"
+      ]
+    },
+    {
       "type" : "shell",
       "inline" : [
         "sudo apt-cache search build-essential",


### PR DESCRIPTION
The problem arises when cloud-init has not finished fully running on
the source AMI by the time that packer starts any provisioning steps

Details here https://github.com/hashicorp/packer/commit/6af2fd5bd08826e8e1a9d78afc017853db58150b

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
