### PR TITLE
Fix node package dependencies on CentOS6 (python 2.6)

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -116,6 +116,9 @@ if !node['cfncluster']['custom_node_package'].nil? && !node['cfncluster']['custo
 else
   # Install cfncluster-node package
   if node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7
+    python_package "pycparser" do
+      version "2.18"
+    end
     # For CentOS 6 use shell_out function in order to have a correct PATH needed to compile cfncluster-node dependencies
     ruby_block "pip_install_cfncluster_node" do
       block do


### PR DESCRIPTION
The root cause of the issue is that a new release of pycparser
https://pypi.org/project/pycparser/#history
which doesn't work with python 2.6 was released.
Our dependencies chain is

pycparser -> cffi -> pynacl -> paramiko -> cfncluster-node

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
