### PR TITLE
Set skip_if_unavailable to true for yum repositories

### DIFF
--- a/recipes/base_install.rb
+++ b/recipes/base_install.rb
@@ -18,6 +18,12 @@ when 'rhel', 'amazon'
   include_recipe 'yum'
   include_recipe "yum-epel" if node['platform_version'].to_i < 7
 
+  unless node['platform_version'].to_i < 7
+    execute 'yum-config-manager_skip_if_unavail' do
+      command "yum-config-manager --setopt=\*.skip_if_unavailable=1 --save"
+    end
+  end
+
   if node['platform'] == 'redhat'
     execute 'yum-config-manager-rhel' do
       command "yum-config-manager --enable #{node['cfncluster']['rhel']['extra_repo']}"


### PR DESCRIPTION
We are setting skip_if_unavailable=1 for all the repositories except
the main one, because it is not reasonable to fail if just a single
repository is down. This is even more true in custom AMIs with
third party repositories.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
