### PR TITLE
Add workaround for the "setup_python" recipe after pip release 18.1

### DIFF
--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -25,12 +25,20 @@ when 'rhel', 'amazon'
       PIP
     end
   else
+    edit_resource(:python_runtime, '2') do
+      # FIXME: https://github.com/poise/poise-python/issues/133
+      pip_version '18.0'
+    end
     python_runtime '2' do
       version '2'
       provider :system
     end
   end
 when 'debian'
+  edit_resource(:python_runtime, '2') do
+    # FIXME: https://github.com/poise/poise-python/issues/133
+    pip_version '18.0'
+  end
   python_runtime '2' do
     version '2'
     provider :system


### PR DESCRIPTION
The setup_python recipe doesn't work with the latest version of pip
18.1 https://pypi.org/project/pip/18.1/#history
Issue is open at https://github.com/poise/poise-python/issues/133
The workaround consists in overriding pip version to 18.0

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
