### PR TITLE
Add possibility to build CfnCluster AMI starting from input AMI ID

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,5 @@
 /spec export-ignore
 /test export-ignore
-build* export-ignore
-packer* export-ignore
 .kitchen* export-ignore
-.gitattributes export-ignore  
+.gitattributes export-ignore
 .gitignore export-ignore

--- a/amis/build_ami.sh
+++ b/amis/build_ami.sh
@@ -11,85 +11,179 @@
 # NOTE: The VPC and the Subnet must be in the us-east-1 region, because the packer templates refer to
 # AMI IDs from this region. Moreover, the CentOs AMIs are private to the CfnCluster AWS account.
 #
-# Usage: build_ami.sh <os> <region> [private|public] [<build-date>]
+# Usage: build_ami.sh --os <os> --region <region> --partition <partition> [--public] [--custom] [--build-date <build-date>]
 #   os: the os to build (supported values: all|centos6|centos7|alinux|ubuntu1404|ubuntu1604)
 #   partition: partition to build in (supported values: commercial|govcloud)
 #   region: region to copy ami too (supported values: all|us-east-1|us-gov-west-1|...)
-#   private|public: specifies AMIs visibility (optional, default is private)
+#   custom: specifies to create the AMI from a custom AMI-id, which must be specified by variable CUSTOM_AMI_ID in the environment (optional)
+#   public: specifies AMIs visibility (optional, default is private)
 #   build-date: timestamp to append to the AMIs names (optional)
 
-set -e
+requirements_check() {
+    which packer >/dev/null 2>&1
+    if [ $? -ne 0 ] ; then
+      echo "packer command not found. Is Packer installed?"
+      echo "Please visit https://www.packer.io/downloads.html for instruction on how to download and install"
+      exit 1
+    fi
 
-os=$1
-partition=$2
-region=$3
-public=$4
-build_date=$5
-
-available_os="centos6 centos7 alinux ubuntu1404 ubuntu1604"
-cwd="$(dirname $0)"
-export VENDOR_PATH="${cwd}/../../vendor/cookbooks"
-
-if [ "x${os}" == "x" ]; then
-  echo "Must provide OS to build."
-  echo "Options: all ${available_os}"
-  exit 1
-fi
-
-if [ "x${region}" == "x" ]; then
-  echo "Must provide AWS region to copy ami into"
-  echo "Options: all us-east-1 us-gov-west-1 ..."
-  exit 1
-fi
-
-if [ "${public}" == "public" ]; then
-  export AMI_PERMS="all"
-fi
-
-if [ "${partition}" == "commercial" ]; then
-  export AWS_REGION="us-east-1"
-elif [ "${partition}" == "govcloud" ]; then
-  export AWS_REGION="us-gov-west-1"
-else
-  echo "Must provide AWS partition to build for."
-  echo "Options: commercial govcloud"
-  exit 1
-fi
-
-if [ "${region}" == "all" ]; then
-  available_regions="$(aws ec2 --region ${AWS_REGION} describe-regions --query Regions[].RegionName --output text | tr '\t' ',')"
-  export BUILD_FOR=${available_regions}
-else
-  export BUILD_FOR=${region}
-fi
-
-RC=0
-
-rm -rf "${VENDOR_PATH}" || RC=1
-berks vendor "${VENDOR_PATH}" --berksfile "${cwd}/../Berksfile" || RC=1
-if [ "x${build_date}" == "x" ]; then
-  export BUILD_DATE=$(date +%Y%m%d%H%M)
-else
-  export BUILD_DATE=${build_date}
-fi
+    which berks >/dev/null 2>&1
+    if [ $? -ne 0 ] ; then
+      echo "berks command not found. Is ChefDK installed?"
+      echo "Please visit https://downloads.chef.io/chefdk/ for instruction on how to download and install"
+      exit 1
+    fi
+}
 
 
-case ${os} in
-  all)
-    for x in ${available_os}; do
-      packer build -machine-readable -var-file="${cwd}/packer_variables.json" "${cwd}/packer_${x}.json"
-      RC=$?
+parse_options() {
+    _os=''
+    _partition=''
+    _region=''
+    _custom=false
+    _public=false
+    _build_date=''
+
+    if [ $# -eq 0 ]; then
+        syntax
+        exit 0
+    fi
+
+    while [ $# -gt 0 ] ; do
+        case "$1" in
+            --os)
+                _os="$2"
+                shift
+            ;;
+            --os=*)
+                _os="${1#*=}"
+            ;;
+            --partition)
+                _partition="$2"
+                shift
+            ;;
+            --partition=*)
+                _partition="${1#*=}"
+            ;;
+            --region)
+                _region="$2"
+                shift
+            ;;
+            --region=*)
+                _region="${1#*=}"
+            ;;
+            --custom)
+                _custom=true
+            ;;
+            --public)
+                _public=true
+            ;;
+            --build-date)
+                _build_date="$2"
+                shift
+            ;;
+            --build-date=*)
+                _build_date="${1#*=}"
+            ;;
+            -h|--help|help)
+                syntax
+                exit 0
+            ;;
+            *)
+                syntax
+                fail "Unrecognized option '$1'"
+            ;;
+        esac
+        shift
     done
-    ;;
-  centos6|centos7|alinux|ubuntu1404|ubuntu1604)
-    packer build -machine-readable -var-file="${cwd}/packer_variables.json" "${cwd}/packer_${os}.json"
-    RC=$?
-    ;;
-  *)
-    echo "Unknown OS: ${os}"
-    RC=1
-    ;;
-esac
+}
 
-echo "RC: ${RC}"
-exit ${RC}
+check_options() {
+    set -e
+
+    available_os="centos6 centos7 alinux ubuntu1404 ubuntu1604"
+    cwd="$(dirname $0)"
+    tmp_dir=$(mktemp -d)
+    export VENDOR_PATH="${tmp_dir}/vendor/cookbooks"
+
+    if [ "${_custom}" == "true" ]; then
+        only=custom-${_os}
+    else
+        only=${_os}
+    fi
+
+    if [ "x${_os}" == "x" ]; then
+      echo "Must provide OS to build. Valid values: ${available_os}"
+      exit 1
+    fi
+
+    if [ "x${_region}" == "x" ]; then
+      echo "Must provide AWS region to copy ami into"
+      echo "Options: all us-east-1 us-gov-west-1 ..."
+      exit 1
+    fi
+
+    if [ "${_public}" == "true" ]; then
+      export AMI_PERMS="all"
+    fi
+
+    if [ "${_partition}" == "commercial" ]; then
+      export AWS_REGION="us-east-1"
+    elif [ "${_partition}" == "govcloud" ]; then
+      export AWS_REGION="us-gov-west-1"
+    else
+      echo "Must provide AWS partition to build for."
+      echo "Options: commercial govcloud"
+      exit 1
+    fi
+
+    if [ "${_region}" == "all" ]; then
+      available_regions="$(aws ec2 --region ${AWS_REGION} describe-regions --query Regions[].RegionName --output text | tr '\t' ',')"
+      export BUILD_FOR=${available_regions}
+    else
+      export BUILD_FOR=${_region}
+    fi
+}
+
+do_command() {
+    RC=0
+
+    rm -rf "${VENDOR_PATH}" || RC=1
+    berks vendor "${VENDOR_PATH}" --berksfile "${cwd}/../Berksfile" || RC=1
+    if [ "x${_build_date}" == "x" ]; then
+      export BUILD_DATE=$(date +%Y%m%d%H%M)
+    else
+      export BUILD_DATE=${_build_date}
+    fi
+
+
+    case ${_os} in
+      all)
+        for x in ${available_os}; do
+          packer build -color=false -var-file="${cwd}/packer_variables.json" "${cwd}/packer_${x}.json"
+          RC=$?
+        done
+        ;;
+      centos6|centos7|alinux|ubuntu1404|ubuntu1604)
+        packer build -color=false -var-file="${cwd}/packer_variables.json" -only=${only} "${cwd}/packer_${_os}.json"
+        RC=$?
+        ;;
+      *)
+        echo "Unknown OS: ${_os}. Valid values: ${available_os}"
+        RC=1
+        ;;
+    esac
+
+    echo "RC: ${RC}"
+    exit ${RC}
+}
+
+
+main() {
+    requirements_check
+    parse_options "$@"
+    check_options
+    do_command
+}
+
+main "$@"

--- a/amis/packer_alinux.json
+++ b/amis/packer_alinux.json
@@ -14,19 +14,21 @@
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
     "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
-    "region" : "{{env `AWS_REGION`}}"
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}"
   },
   "builders" : [
     {
+      "name" : "alinux",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
           "name": "amzn-ami-hvm-*.*.*.*-x86_64-gp2",
-          "root-device-type": "ebs",
-          "owner-alias": "amazon"
+          "root-device-type": "ebs"
         },
+        "owners": ["amazon"],
         "most_recent": true
       },
       "ami_regions" : "{{user `build_for`}}",
@@ -34,13 +36,14 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ec2-user",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
       "associate_public_ip_address" : true,
       "sriov_support" : true,
       "ena_support" : true,
+      "shutdown_behavior" : "terminate",
       "tags" : {
         "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
         "build_date" : "{{user `build_date`}}"
@@ -53,6 +56,59 @@
         {
           "device_name" : "/dev/xvda",
           "volume_size" : "15",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
+    },
+    {
+      "name" : "custom-alinux",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "ec2-user",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-amzn-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : true,
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/xvda",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },
@@ -115,6 +171,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["alinux"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -131,6 +188,7 @@
     },
     {
       "type" : "shell",
+      "only": ["alinux"],
       "expect_disconnect" : "true",
       "inline" : [
         "sudo reboot"
@@ -138,6 +196,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["alinux"],
       "pause_before": "2m",
       "json" : {
         "cfncluster" : {
@@ -146,6 +205,18 @@
           }
         }
       },
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::default"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["custom-alinux"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -166,6 +237,13 @@
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["custom-alinux"],
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
       ]
     }
   ]

--- a/amis/packer_centos6.json
+++ b/amis/packer_centos6.json
@@ -14,10 +14,12 @@
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
     "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
-    "region" : "{{env `AWS_REGION`}}"
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}"
   },
   "builders" : [
     {
+      "name" : "centos6",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
       "source_ami_filter": {
@@ -34,13 +36,14 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
       "associate_public_ip_address" : true,
       "sriov_support" : true,
       "ena_support" : true,
+      "shutdown_behavior" : "terminate",
       "tags" : {
         "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
         "build_date" : "{{user `build_date`}}"
@@ -75,9 +78,69 @@
           "no_device" : true
         }
       ]
+    },
+    {
+      "name" : "custom-centos6",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "centos",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-centos6-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : true,
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sda1",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
     }
   ],
   "provisioners" : [
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo yum -y install epel-release",
+        "sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config"
+      ]
+    },
     {
       "type" : "shell",
       "inline" : [
@@ -115,6 +178,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["centos6"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -131,6 +195,7 @@
     },
     {
       "type" : "shell",
+      "only": ["centos6"],
       "expect_disconnect" : "true",
       "inline" : [
         "sudo /etc/init.d/sshd stop",
@@ -140,6 +205,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["centos6"],
       "pause_before": "2m",
       "json" : {
         "cfncluster" : {
@@ -148,6 +214,18 @@
           }
         }
       },
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::default"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["custom-centos6"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -175,6 +253,13 @@
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["custom-centos6"],
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
       ]
     }
   ]

--- a/amis/packer_centos7.json
+++ b/amis/packer_centos7.json
@@ -14,10 +14,12 @@
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
     "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
-    "region" : "{{env `AWS_REGION`}}"
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}"
   },
   "builders" : [
     {
+      "name" : "centos7",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
       "source_ami_filter": {
@@ -34,13 +36,14 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "centos",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
       "associate_public_ip_address" : true,
       "sriov_support" : true,
       "ena_support" : true,
+      "shutdown_behavior" : "terminate",
       "tags" : {
         "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
         "build_date" : "{{user `build_date`}}"
@@ -75,9 +78,68 @@
           "no_device" : true
         }
       ]
+    },
+    {
+      "name" : "custom-centos7",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "centos",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-centos7-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : true,
+      "sriov_support" : true,
+      "ena_support" : true,
+      "tags" : {
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sda1",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
     }
   ],
   "provisioners" : [
+    {
+      "type" : "shell",
+      "inline" : [
+        "sudo yum -y install epel-release",
+        "sudo /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config"
+      ]
+    },
     {
       "type" : "shell",
       "inline" : [
@@ -115,6 +177,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["centos7"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -131,6 +194,7 @@
     },
     {
       "type" : "shell",
+      "only": ["centos7"],
       "expect_disconnect" : "true",
       "inline" : [
         "sudo reboot"
@@ -138,6 +202,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["centos7"],
       "pause_before": "2m",
       "json" : {
         "cfncluster" : {
@@ -156,10 +221,23 @@
       ]
     },
     {
+      "type" : "chef-solo",
+      "only": ["custom-centos7"],
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::default"
+      ]
+    },
+    {
       "type" : "shell",
       "inline" : [
         "wget -O /tmp/aws-cfn-bootstrap-latest.zip https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.zip",
-        "sudo pip install /tmp/aws-cfn-bootstrap-latest.zip"
+        "which pip2",
+        "if [ $? -eq 0 ]; then sudo pip2 install /tmp/aws-cfn-bootstrap-latest.zip; else sudo pip install /tmp/aws-cfn-bootstrap-latest.zip; fi"
       ]
     },
     {
@@ -179,6 +257,13 @@
       "type" : "shell",
       "inline" : [
         "sudo sed -i -e \"s/\\s*Defaults\\s\\s*requiretty//# Defaults  requiretty/\" /etc/sudoers"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["custom-centos7"],
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
       ]
     }
   ]

--- a/amis/packer_ubuntu1404.json
+++ b/amis/packer_ubuntu1404.json
@@ -14,10 +14,12 @@
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
     "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
-    "region" : "{{env `AWS_REGION`}}"
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}"
   },
   "builders" : [
     {
+      "name" : "ubuntu1404",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
       "source_ami_filter": {
@@ -34,13 +36,14 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
       "associate_public_ip_address" : true,
       "sriov_support" : true,
       "ena_support" : true,
+      "shutdown_behavior" : "terminate",
       "tags" : {
         "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
         "build_date" : "{{user `build_date`}}"
@@ -53,6 +56,59 @@
         {
           "device_name" : "/dev/sda1",
           "volume_size" : "15",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
+    },
+    {
+      "name" : "custom-ubuntu1404",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "ubuntu",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1404-lts-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : true,
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sda1",
           "volume_type" : "gp2",
           "delete_on_termination" : true
         },
@@ -129,6 +185,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["ubuntu1404"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -145,6 +202,7 @@
     },
     {
       "type" : "shell",
+      "only": ["ubuntu1404"],
       "expect_disconnect" : "true",
       "inline" : [
         "sudo reboot"
@@ -152,6 +210,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["ubuntu1404"],
       "pause_before": "2m",
       "json" : {
         "cfncluster" : {
@@ -160,6 +219,18 @@
           }
         }
       },
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::default"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["custom-ubuntu1404"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -187,6 +258,13 @@
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["custom-ubuntu1404"],
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
       ]
     }
   ]

--- a/amis/packer_ubuntu1604.json
+++ b/amis/packer_ubuntu1604.json
@@ -14,10 +14,12 @@
     "subnet_id" : "{{env `AWS_SUBNET_ID`}}",
     "vpc_id" : "{{env `AWS_VPC_ID`}}",
     "ami_name_prefix" : "{{env `AMI_NAME_PREFIX`}}",
-    "region" : "{{env `AWS_REGION`}}"
+    "region" : "{{env `AWS_REGION`}}",
+    "custom_ami_id" : "{{env `CUSTOM_AMI_ID`}}"
   },
   "builders" : [
     {
+      "name" : "ubuntu1604",
       "type" : "amazon-ebs",
       "region" : "{{user `region`}}",
       "source_ami_filter": {
@@ -34,13 +36,14 @@
       "instance_type" : "{{user `instance_type`}}",
       "ssh_username" : "ubuntu",
       "ssh_pty" : true,
-      "ami_name" : "{{user `ami_name_prefix`}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
       "subnet_id" : "{{user `subnet_id`}}",
       "vpc_id" : "{{user `vpc_id`}}",
       "skip_region_validation" : true,
       "associate_public_ip_address" : true,
       "sriov_support" : true,
       "ena_support" : true,
+      "shutdown_behavior" : "terminate",
       "tags" : {
         "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
         "build_date" : "{{user `build_date`}}"
@@ -75,6 +78,59 @@
           "no_device" : true
         }
       ]
+    },
+    {
+      "name" : "custom-ubuntu1604",
+      "type" : "amazon-ebs",
+      "region" : "{{user `region`}}",
+      "source_ami": "{{user `custom_ami_id`}}",
+      "ami_regions" : "{{user `build_for`}}",
+      "ami_groups" : "{{user `ami_perms`}}",
+      "instance_type" : "{{user `instance_type`}}",
+      "ssh_username" : "ubuntu",
+      "ssh_pty" : true,
+      "ami_name" : "{{user `ami_name_prefix` | clean_ami_name}}cfncluster-{{user `cfncluster_version`}}-ubuntu-1604-lts-hvm-{{user `build_date`}}",
+      "subnet_id" : "{{user `subnet_id`}}",
+      "vpc_id" : "{{user `vpc_id`}}",
+      "skip_region_validation" : true,
+      "associate_public_ip_address" : true,
+      "sriov_support" : true,
+      "ena_support" : true,
+      "shutdown_behavior" : "terminate",
+      "tags" : {
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "run_tags" : {
+        "Name": "Packer Builder {{user `custom_ami_id`}}",
+        "cfncluster_version" : "cfncluster-{{user `cfncluster_version`}}",
+        "build_date" : "{{user `build_date`}}"
+      },
+      "launch_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sda1",
+          "volume_type" : "gp2",
+          "delete_on_termination" : true
+        },
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ],
+      "ami_block_device_mappings" : [
+        {
+          "device_name" : "/dev/sdb",
+          "no_device" : true
+        },
+        {
+          "device_name" : "/dev/sdc",
+          "no_device" : true
+        }
+      ]
     }
   ],
   "provisioners" : [
@@ -87,6 +143,9 @@
     {
       "type" : "shell",
       "inline" : [
+        "sudo sed -i 's/APT::Periodic::Update-Package-Lists \"1\"/APT::Periodic::Update-Package-Lists \"0\"/' /etc/apt/apt.conf.d/20auto-upgrades",
+        "sudo sed -i 's/APT::Periodic::Update-Package-Lists \"1\"/APT::Periodic::Update-Package-Lists \"0\"/' /etc/apt/apt.conf.d/10periodic",
+        "sudo sed -i 's/APT::Periodic::Unattended-Upgrade \"1\"/APT::Periodic::Unattended-Upgrade \"0\"/' /etc/apt/apt.conf.d/20auto-upgrades",
         "sudo apt-cache search build-essential",
         "sudo apt-get clean",
         "sudo apt-get update"
@@ -129,6 +188,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["ubuntu1604"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -145,6 +205,7 @@
     },
     {
       "type" : "shell",
+      "only": ["ubuntu1604"],
       "expect_disconnect" : "true",
       "inline" : [
         "sudo reboot"
@@ -152,6 +213,7 @@
     },
     {
       "type" : "chef-solo",
+      "only": ["ubuntu1604"],
       "pause_before": "2m",
       "json" : {
         "cfncluster" : {
@@ -160,6 +222,18 @@
           }
         }
       },
+      "remote_cookbook_paths" : [
+        "/etc/chef/cookbooks"
+      ],
+      "skip_install" : "true",
+      "execute_command" : "sudo chef-client -z --no-color -c {{.ConfigPath}} -j {{.JsonPath}}",
+      "run_list" : [
+        "cfncluster::default"
+      ]
+    },
+    {
+      "type" : "chef-solo",
+      "only": ["custom-ubuntu1604"],
       "remote_cookbook_paths" : [
         "/etc/chef/cookbooks"
       ],
@@ -187,6 +261,13 @@
       "inline" : [
         "sudo rm -rf /tmp/* /var/tmp/* && sudo rm -f /root/.ssh/authorized_keys && rm -f ~/.ssh/authorized_keys",
         "echo cfncluster-{{user `cfncluster_version`}} | sudo tee /opt/cfncluster/.bootstrapped"
+      ]
+    },
+    {
+      "type" : "shell",
+      "only": ["custom-ubuntu1604"],
+      "inline" : [
+        "sudo /usr/local/sbin/ami_cleanup.sh"
       ]
     }
   ]

--- a/recipes/_setup_python.rb
+++ b/recipes/_setup_python.rb
@@ -25,22 +25,32 @@ when 'rhel', 'amazon'
       PIP
     end
   else
-    edit_resource(:python_runtime, '2') do
+    bash 'pin pip to version 18.0' do
       # FIXME: https://github.com/poise/poise-python/issues/133
-      pip_version '18.0'
+      code <<-PIP
+        which pip
+        if [ $? -eq 0 ]; then pip install pip==18.0; fi
+      PIP
     end
     python_runtime '2' do
       version '2'
       provider :system
+      # FIXME: https://github.com/poise/poise-python/issues/133
+      pip_version '18.0'
     end
   end
 when 'debian'
-  edit_resource(:python_runtime, '2') do
+  bash 'pin pip to version 18.0' do
     # FIXME: https://github.com/poise/poise-python/issues/133
-    pip_version '18.0'
+    code <<-PIP
+      which pip
+      if [ $? -eq 0 ]; then pip install pip==18.0; fi
+    PIP
   end
   python_runtime '2' do
     version '2'
     provider :system
+    # FIXME: https://github.com/poise/poise-python/issues/133
+    pip_version '18.0'
   end
 end


### PR DESCRIPTION
- Add packer builders to work with input AMI ID
- Fix recipes to work with AMI having pip > 18.0
- Refactor build script to use keyword params instead of positional

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
